### PR TITLE
Add space-bench binary and other minor improvements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@
   > :construction_worker: DELETE THIS NOTE
 
 - [ ] I have confirmed that all tests pass locally.
-  > :construction_worker: Run all tests locally via `cargo test -- --include-ignored`
+  > :construction_worker: Run all tests locally via `cargo test --all-features -- --include-ignored`
   > :information_source: This will include the TUI interactive tests, so make sure you run this in a maximized terminal window. Other platforms will be tested on the build agent.
   > :construction_worker: DELETE THIS NOTE
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,8 +29,8 @@
 
 - [ ] I have confirmed that my changes do not negatively impact performance by manually comparing before and
       after performance against a suitable local directory tree.
-  > :construction_worker: Run the release build in non-interactive mode and with timing output via `cargo run --release --non-interactive --show-timing`
-  > :information_source: A benchmark will be run on the build agent.
+  > :construction_worker: Run the latest release of [space-bench for your platform](https://github.com/emilevr/space/releases), then run the local release build of `space-bench` via `cargo run --bin space-bench --release --all-features -- <tree_path>` for a comparative test.
+  > :information_source: A comparative benchmark will be run on the build agent.
   > :construction_worker: DELETE THIS NOTE
 
 - [ ] I have confirmed that code coverage has not regressed as a result of my changes.

--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -25,14 +25,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - id: linux
-            runs-on: ubuntu-latest
+          - runs-on: ubuntu-latest
             target: x86_64-unknown-linux-musl
-          - id: macos
-            runs-on: macos-latest
+          - runs-on: macos-latest
             target: x86_64-apple-darwin
-          - id: windows
-            runs-on: windows-latest
+          - runs-on: windows-latest
             target: x86_64-pc-windows-msvc
     env:
       RUST_LOG: trace
@@ -59,51 +56,67 @@ jobs:
         run: buildit version
 
       - name: Build binaries for packaging
-        run: cargo build --release
+        run: cargo build --release --all-features
 
       - name: Package for distribution (Linux and MacOS)
         if: ${{ matrix.runs-on == 'ubuntu-latest' || matrix.runs-on == 'macos-latest' }}
         run: |
-          BIN_DIR_PATH=./target/release
-          BIN_FILE_PATH=./target/release/space
-          ARCHIVE_FILE_PATH=./artifacts/dist/space-${{ matrix.target }}.tar.gz
+          ARCHIVE_FILE_DIR=./artifacts/dist
+          mkdir -p $ARCHIVE_FILE_DIR
 
-          # Strip debug symbols
-          strip $BIN_FILE_PATH
+          BIN_FILE_NAMES=(space space-bench)
+          for BIN_FILE_NAME in "${BIN_FILE_NAMES[@]}"
+          do
+            BIN_DIR_PATH=./target/release
+            BIN_FILE_PATH=./target/release/${BIN_FILE_NAME}
+            ARCHIVE_FILE_NAME=${BIN_FILE_NAME}-${{ matrix.target }}.tar.gz
+            ARCHIVE_FILE_PATH=${ARCHIVE_FILE_DIR}/${ARCHIVE_FILE_NAME}
+            ACHIVE_HASH_FILE_NAME=${ARCHIVE_FILE_NAME}.sha256
 
-          mkdir -p ./artifacts/dist
+            echo "Stripping debug symbols from ${BIN_FILE_PATH}"
+            strip ${BIN_FILE_PATH}
 
-          # Compress
-          tar -C $BIN_DIR_PATH -czf $ARCHIVE_FILE_PATH .
+            echo "Compressing ${BIN_FILE_PATH} to ${ARCHIVE_FILE_PATH}"
+            tar -C $BIN_DIR_PATH -czf $ARCHIVE_FILE_PATH $BIN_FILE_NAME
 
-          # Calculate hash
-          shasum -a 256 $ARCHIVE_FILE_PATH > ${ARCHIVE_FILE_PATH}.sha256
+            pushd $ARCHIVE_FILE_DIR > /dev/null
+
+            echo "Calculating SHA256 hash of ${ARCHIVE_FILE_NAME} to ${ACHIVE_HASH_FILE_NAME}"
+            shasum -a 256 $ARCHIVE_FILE_NAME > $ACHIVE_HASH_FILE_NAME
+
+            popd > /dev/null
+          done
 
       - name: Package for distribution (Windows)
         if: ${{ matrix.runs-on == 'windows-latest' }}
         run: |
-          $binFilePath = './target/release/space.exe'
-          $archiveFilePath = "./artifacts/dist/space-${{ matrix.target }}.zip"
-
           New-Item -Type Directory -Path ./artifacts/dist -Force
 
-          $compress = @{
-            Path = $binFilePath
-            DestinationPath = $archiveFilePath
-            CompressionLevel = "Optimal"
-          }
-          Compress-Archive @compress
+          $binFileNames = @('space', 'space-bench')
+          foreach ($fileName in $binFileNames) {
+            $binFilePath = "./target/release/${fileName}.exe"
+            $archiveFilePath = "./artifacts/dist/${fileName}-${{ matrix.target }}.zip"
+            $archiveHashFilePath = "${archiveFilePath}.sha256"
 
-          # Calculate hash
-          Get-FileHash -Path $archiveFilePath -Algorithm SHA256 `
-            | Select-Object @{Label='Hash';Expression={$_.Hash.ToLower()}} `
-            | Select-Object -ExpandProperty Hash `
-            > "${archiveFilePath}.sha256"
+            Write-Host "Compressing ${binFilePath} to ${archiveFilePath}"
+            $compress = @{
+              Path = $binFilePath
+              DestinationPath = $archiveFilePath
+              CompressionLevel = "Optimal"
+            }
+            Compress-Archive @compress
+
+            Write-Host "Calculating SHA256 of ${archiveFilePath} to ${archiveHashFilePath}"
+            Get-FileHash -Path $archiveFilePath -Algorithm SHA256 `
+              | Select-Object @{Label='Hash';Expression={$_.Hash.ToLower()}} `
+              | Select-Object -ExpandProperty Hash `
+              > $archiveHashFilePath
+          }
 
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: dist-${{ matrix.id }}
+          name: dist-${{ matrix.target }}
           path: ./artifacts/dist
 
   create-release:
@@ -141,21 +154,26 @@ jobs:
           $isPreRelease = $true
           $preReleaseParam = '--prerelease'
           if ($isPreReleaseVar -eq 'false') {
+            Write-Host 'This is a release'
             $isPreRelease = $false
             $preReleaseParam = $null
+          } else {
+            Write-Host 'This is a pre-release'
           }
 
           $hasPrevReleaseVersion = -not [string]::IsNullOrWhiteSpace($prevReleaseVersion)
           if ($hasPrevReleaseVersion) {
+            Write-Host "Will create release $calculatedVersion from tag $prevReleaseVersion to tag $calculatedVersion"
             gh release create $calculatedVersion $preReleaseParam --generate-notes --latest --notes-start-tag $prevReleaseVersion --title $calculatedVersion
           } else {
+            Write-Host "Will create first release $calculatedVersion"
             gh release create $calculatedVersion $preReleaseParam --notes 'First release' --title $calculatedVersion
           }
 
-          $distributions = @('linux', 'macos', 'windows')
-          foreach ($distro in $distributions) {
-            $artifactsDir = "./dist-$distro"
-            if (Test-Path $artifactsDir) {
-              gh release upload $calculatedVersion $artifactsDir/*
+          $targets = @('x86_64-unknown-linux-musl', 'x86_64-apple-darwin', 'x86_64-pc-windows-msvc')
+          foreach ($target in $targets) {
+            $targetArtifactsDir = "./dist-$target"
+            if (Test-Path $targetArtifactsDir) {
+              gh release upload $calculatedVersion $targetArtifactsDir/*
             }
           }

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,8 +2,6 @@ name: Lint
 on:
   pull_request:
   push:
-    branches:
-      - '*'
     tags-ignore:
       - '*.*.*'
   workflow_call:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,8 @@ name: Lint
 on:
   pull_request:
   push:
+    branches-ignore:
+      - ' '
     tags-ignore:
       - '*.*.*'
   workflow_call:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches-ignore:
+      - ' '
     tags-ignore:
       - '*.*.*'
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,6 @@ name: Test
 on:
   pull_request:
   push:
-    branches:
-      - '*'
     tags-ignore:
       - '*.*.*'
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ coverage/
 tmp.sample/
 tmp.sample.zip
 target_coverage/
+
+# Artifacts
+artifacts/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,12 +331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,15 +754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,7 +880,6 @@ dependencies = [
  "itertools 0.11.0",
  "paste",
  "strum",
- "time",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1279,25 +1263,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426f806f4089c493dcac0d24c29c01e2c38baf8e30f1b716ee37e83d200b18fe"
-dependencies = [
- "deranged",
- "libc",
- "num_threads",
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ name = "space"
 path = "src/main.rs"
 required-features = ["cli"]
 
+[[bin]]
+name = "space-bench"
+path = "src/space_bench.rs"
+required-features = ["bench"]
+
 [[bench]]
 name = "directory_item_build"
 harness = false
@@ -32,16 +37,18 @@ harness = false
 #default = ["cli", "nightly"]
 default = ["cli"]
 nightly = []
-cli = ["clap/derive", "crossterm", "dirs", "ratatui/all-widgets", "serde/derive", "serde_yaml"]
+cli = ["clap/derive", "crossterm", "dirs", "ratatui", "serde/derive", "serde_yaml", "log", "log4rs"]
+bench = ["clap/derive", "crossterm", "dirs", "ratatui", "criterion"]
 
 [dependencies]
 anyhow = "^1.0.72"
 clap = { version = "^4.3.21", optional = true }
+criterion = { version = "^0.5.1", default-features = false, features = [], optional = true }
 crossterm = { version = "^0.27.0", optional = true }
 dirs = { version = "^5.0.1", optional = true }
-log = "^0.4.20"
-log4rs = "^1.2.0"
-ratatui = { version = "^0.23.0", features = ["all-widgets"], optional = true }
+log = { version = "^0.4.20", optional = true }
+log4rs = { version = "^1.2.0", optional = true }
+ratatui = { version = "^0.23.0", default-features = false, features = ["crossterm"], optional = true }
 rayon = "^1.7.0"
 serde = { version = "^1.0.188", features = ["derive"], optional = true }
 serde_yaml = { version = "^0.9.25", optional = true }

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ benchmark tasks.
 In order for code coverage to be generated, ensure you have installed *llvm-tools* via
 `rustup component add llvm-tools`.
 
-To generate a code coverage report, run `cargo buildit coverage`.
+To generate a code coverage report, run `cargo install --path ./buildit && buildit coverage --include-ignored`.
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -101,16 +101,19 @@ After the initial checkout please run the post-checkout hook manually via:
 
 This will setup the hooks directory, enabling the pre-commit hook to run linting, code coverage and benchmarks.
 
-### Building and running the CLI
+### Building and running the space CLI
 
-To build the library and CLI, simply run `cargo build` from the repo root directory. The binaries will be built
-in the `./target/debug` directory. Alternatively use `cargo run` to build and run the CLI.
+To build the library and binaries, simply run `cargo build --all-features` from the repo root directory.
+The binaries will be built in the `./target/debug` directory. Alternatively use `cargo run --bin space` to
+build and run the `space` CLI.
 
 > :information_source: All the commands listed below should also be run from the repo root.
 
 ### Running Tests
 
-Run `cargo test`.
+- Run non-interactive tests via `cargo test --all-features`.
+- Run all tests, including interactive. ones via `cargo test --all-features -- --include-ignored`. Note:this
+  requires a large/maximized terminal window.
 
 ### Running code format and lint tests
 

--- a/buildit/src/coverage.rs
+++ b/buildit/src/coverage.rs
@@ -84,7 +84,7 @@ impl BuildItCommand for CoverageCommand {
         env::set_var("CARGO_TARGET_DIR", target_coverage_dir);
 
         println!("👷 Running Tests with Code Coverage ...");
-        let mut args = vec!["test"];
+        let mut args = vec!["test", "--all-features"];
         if let Some(package) = &self.package {
             args.push("--package");
             args.push(package);
@@ -126,11 +126,10 @@ impl BuildItCommand for CoverageCommand {
             output_types,
             "--branch",
             "--excl-line",
-            // Exlude the following lines:
+            // Exclude the following lines:
             //  ^\\s*(debug_)?assert(_eq|_ne)?!                                             => debug_assert and assert variants
-            //  ^\\s*#\\[cfg\\s*\\(.*\\]\\s*$                                               => cfg attributes
-            //  ^\\s*#\\[inline\\s*\\(.*\\]\\s*$                                            => inline attributes
-            //  ^\\s*#\\[derive\\s*\\(.*\\]\\s*$                                            => derive attributes
+            //  ^\\s*#\\[.*$                                                                => lines containing only an attribute
+            //  ^\\s*#!\\[.*$                                                               => lines containing only a crate attribute
             //  ^\\s*\\}\\s*else\\s*\\{\\s*$                                                => lines containing only "} else {"
             //  ^\\s*//.*$                                                                  => lines containing only a comment
             //  ^\\s*(pub|pub\\s*\\(\\s*crate\\s*\\)\\s*)?\\s*fn\\s+.*\\s*[(){}]*\\s*$      => lines containing only a fn definition
@@ -141,9 +140,8 @@ impl BuildItCommand for CoverageCommand {
             //  ^\\s*[{}(),;\\[\\] ]*\\s*$                                                  => lines with only delimiters or whitespace, no logic
             //  ^\\s*impl\\s+.*\\s+for\\s+.*\\s+\\{\\s*$                                    => lines containing only an impl declaration
             "^\\s*(debug_)?assert(_eq|_ne)?!\
-                |^\\s*#\\[cfg\\s*\\(.*\\]\\s*$\
-                |^\\s*#\\[inline\\s*\\(.*\\]\\s*$\
-                |^\\s*#\\[derive\\s*\\(.*\\]\\s*$\
+                |^\\s*#\\[.*$
+                |^\\s*#!\\[.*$
                 |^\\s*\\}\\s*else\\s*\\{\\s*$\
                 |^\\s*//.*$\
                 |^\\s*(pub|pub\\s*\\(\\s*crate\\s*\\)\\s*)?\\s*fn\\s+.*\\s*[(){}]*\\s*$\

--- a/src/cli/cli_command.rs
+++ b/src/cli/cli_command.rs
@@ -1,7 +1,6 @@
-use std::{any::Any, io::Write};
+use std::io::Write;
 
 pub trait CliCommand {
-    fn prepare(&mut self) -> anyhow::Result<()>;
+    fn prepare(&mut self) -> anyhow::Result<&mut Self>;
     fn run<W: Write>(&mut self, writer: &mut W) -> anyhow::Result<()>;
-    fn as_any(&self) -> &dyn Any;
 }

--- a/src/cli/row_item.rs
+++ b/src/cli/row_item.rs
@@ -145,12 +145,17 @@ impl RowItem {
 
     pub fn expand_all_children(&mut self) {
         if self.has_children {
-            for child in &self.children {
-                let mut child = child.borrow_mut();
-                if child.has_children {
-                    child.expanded = true;
-                    child.expand_all_children();
+            if self.expanded {
+                for child in &self.children {
+                    let mut child = child.borrow_mut();
+                    if child.has_children {
+                        child.expanded = true;
+                        child.expand_all_children();
+                    }
                 }
+            } else {
+                self.expanded = true;
+                self.collapse_all_children();
             }
         }
     }

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -5,7 +5,6 @@ use super::{
         EXPAND_INDICATOR_COLUMN_WIDTH, INCL_PERCENTAGE_COLUMN_WIDTH,
     },
 };
-use crate::VERSION;
 #[cfg(not(test))]
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::{
@@ -31,6 +30,8 @@ use std::{
 #[cfg(test)]
 #[path = "./tui_test.rs"]
 mod tui_test;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const KEY_HELP_KEY_FG_COLOR: Color = Color::Rgb(88, 144, 255);
 const TABLE_HEADER_BG_COLOR: Color = Color::Rgb(64, 64, 192);

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -498,8 +498,9 @@ fn render_help<B: Backend>(f: &mut Frame<B>) {
                 Cell::from(format!("{EXPAND_SELECTED_CHILDREN_KEY:^key_column_size$}"))
                     .style(key_style),
                 Cell::from(""),
-                Cell::from("Expand all children of the selected directory item"),
-            ]),
+                Cell::from("If selected item is collapsed, then expand and show collapsed children\nIf selected directory item is expanded, then expand all descendants"),
+            ])
+            .height(2),
             Row::new(Vec::<Cell>::with_capacity(0)),
             Row::new(vec![
                 Cell::from(format!(

--- a/src/cli/view_command_test.rs
+++ b/src/cli/view_command_test.rs
@@ -27,7 +27,6 @@ fn single_target_path_that_does_not_exist_should_fail() -> anyhow::Result<()> {
         size_display_format: None,
         size_threshold_percentage: 1,
         non_interactive: true,
-        show_timing: false,
         total_size_in_bytes: 0,
     };
 
@@ -49,13 +48,13 @@ fn add_row_item_given_item_of_size_below_threshold_does_not_add_item() {
         size_display_format: None,
         size_threshold_percentage: 1,
         non_interactive: false,
-        show_timing: false,
         total_size_in_bytes: 1000000,
     };
     let item = DirectoryItem {
         path: Arc::new(PathBuf::from("/some/path")),
         size_in_bytes: Size::default(),
         children: vec![],
+        child_count: 0,
         item_type: DirectoryItemType::Unknown,
     };
     let mut rows = vec![];
@@ -68,7 +67,7 @@ fn add_row_item_given_item_of_size_below_threshold_does_not_add_item() {
 }
 
 #[test]
-fn trace_space_given_no_target_paths_traces_current_dir() -> anyhow::Result<()> {
+fn analyze_space_given_no_target_paths_traces_current_dir() -> anyhow::Result<()> {
     // Arrange
     let temp_dir = create_test_directory_tree()?;
     let current_dir = std::env::current_dir()?;
@@ -79,12 +78,11 @@ fn trace_space_given_no_target_paths_traces_current_dir() -> anyhow::Result<()> 
         size_display_format: None,
         size_threshold_percentage: 1,
         non_interactive: true,
-        show_timing: false,
         total_size_in_bytes: 0,
     };
 
     // Act
-    let items = view_command.trace_space();
+    let items = view_command.analyze_space();
 
     // Assert
     assert_eq!(1, items.len());
@@ -200,7 +198,6 @@ fn run_given_no_size_display_format_defaults_to_metric() -> anyhow::Result<()> {
         size_display_format: None,
         size_threshold_percentage: 1,
         non_interactive: true,
-        show_timing: false,
         total_size_in_bytes: 0,
     };
 
@@ -235,7 +232,6 @@ fn run_with_size_display_format_uses_that_format(
         size_display_format: Some(size_display_format),
         size_threshold_percentage: 1,
         non_interactive: true,
-        show_timing: false,
         total_size_in_bytes: 0,
     };
 
@@ -264,7 +260,6 @@ fn run_given_single_target_path_shows_expected_duration_prompt() -> anyhow::Resu
         size_display_format: None,
         size_threshold_percentage: 100,
         non_interactive: true,
-        show_timing: false,
         total_size_in_bytes: 0,
     };
 
@@ -294,7 +289,6 @@ fn run_given_multiple_target_paths_shows_expected_duration_prompt() -> anyhow::R
         size_display_format: None,
         size_threshold_percentage: 100,
         non_interactive: true,
-        show_timing: false,
         total_size_in_bytes: 0,
     };
 
@@ -308,35 +302,6 @@ fn run_given_multiple_target_paths_shows_expected_duration_prompt() -> anyhow::R
 
     delete_test_directory_tree(&temp_dir1);
     delete_test_directory_tree(&temp_dir2);
-
-    Ok(())
-}
-
-#[test]
-// Ignore this test by default as it needs to be run in a real terminal, similar to the TUI tests, which does
-// not work on build agents for some operating systems. It will be included with those on the build agent
-// using an appropriate terminal multiplexer.
-#[ignore]
-fn run_with_show_timings_should_output_timing() -> anyhow::Result<()> {
-    // Arrange
-    let mut output = TestOut::new();
-    let temp_dir = create_test_directory_tree()?;
-    let mut view_command = ViewCommand {
-        target_paths: Some(vec![temp_dir.clone()]),
-        size_display_format: Some(SizeDisplayFormat::Metric),
-        size_threshold_percentage: 100,
-        non_interactive: true,
-        show_timing: true,
-        total_size_in_bytes: 0,
-    };
-
-    // Act
-    view_command.run(&mut output)?;
-
-    // Assert
-    output.expect("Elapsed time:")?;
-
-    delete_test_directory_tree(&temp_dir);
 
     Ok(())
 }

--- a/src/cli/view_state_test_utils.rs
+++ b/src/cli/view_state_test_utils.rs
@@ -45,7 +45,6 @@ pub(crate) fn make_test_view_state_from_path(
         Some(size_display_format.clone()),
         (size_threshold_fraction * 100f32) as u8,
         false,
-        false,
     );
     let items = view_command.get_directory_items();
     let items = view_command.get_row_items(items, 0f32);

--- a/src/directory_item_test.rs
+++ b/src/directory_item_test.rs
@@ -21,10 +21,12 @@ fn cmp_with_given_size_in_bytes_returns_correct_ordering(
         path: Arc::new(PathBuf::from("/1")),
         item_type: DirectoryItemType::Directory,
         size_in_bytes: Size::new(size_in_bytes_1),
+        child_count: 1,
         children: vec![DirectoryItem {
             path: Arc::new(PathBuf::from("/1/1")),
             size_in_bytes: Size::new(size_in_bytes_1),
             children: vec![],
+            child_count: 0,
             item_type: DirectoryItemType::File,
         }],
     };
@@ -32,6 +34,7 @@ fn cmp_with_given_size_in_bytes_returns_correct_ordering(
         path: Arc::new(PathBuf::from("/2")),
         size_in_bytes: Size::new(size_in_bytes_2),
         children: vec![],
+        child_count: 0,
         item_type: DirectoryItemType::Directory,
     };
 
@@ -56,10 +59,12 @@ fn partial_cmp_with_given_size_in_bytes_returns_correct_ordering(
         path: Arc::new(PathBuf::from("/2")),
         item_type: DirectoryItemType::Directory,
         size_in_bytes: Size::new(size_in_bytes_1),
+        child_count: 1,
         children: vec![DirectoryItem {
             path: Arc::new(PathBuf::from("/2/1")),
             item_type: DirectoryItemType::File,
             size_in_bytes: Size::new(size_in_bytes_1),
+            child_count: 0,
             children: vec![],
         }],
     };
@@ -67,6 +72,7 @@ fn partial_cmp_with_given_size_in_bytes_returns_correct_ordering(
         path: Arc::new(PathBuf::from("/3")),
         item_type: DirectoryItemType::File,
         size_in_bytes: Size::new(size_in_bytes_2),
+        child_count: 0,
         children: vec![],
     };
 
@@ -91,10 +97,12 @@ fn eq_with_given_size_in_bytes_returns_correct_result(
         path: Arc::new(PathBuf::from("/3")),
         item_type: DirectoryItemType::Directory,
         size_in_bytes: Size::new(size_in_bytes_1),
+        child_count: 1,
         children: vec![DirectoryItem {
             path: Arc::new(PathBuf::from("/3/1")),
             item_type: DirectoryItemType::Directory,
             size_in_bytes: Size::new(size_in_bytes_1),
+            child_count: 0,
             children: vec![],
         }],
     };
@@ -102,6 +110,7 @@ fn eq_with_given_size_in_bytes_returns_correct_result(
         path: Arc::new(PathBuf::from("/4")),
         item_type: DirectoryItemType::Directory,
         size_in_bytes: Size::new(size_in_bytes_2),
+        child_count: 0,
         children: vec![],
     };
 
@@ -159,10 +168,12 @@ fn debug_succeeds() {
         path: Arc::new(PathBuf::from("/1")),
         item_type: DirectoryItemType::Directory,
         size_in_bytes: Size::new(777),
+        child_count: 1,
         children: vec![DirectoryItem {
             path: Arc::new(PathBuf::from("/2/3")),
             item_type: DirectoryItemType::Directory,
             size_in_bytes: Size::new(778),
+            child_count: 0,
             children: vec![],
         }],
     };
@@ -210,6 +221,7 @@ fn get_fraction_given_total_size_in_bytes_of_0_should_return_0() {
         path: Arc::new(PathBuf::from("/1")),
         item_type: DirectoryItemType::File,
         size_in_bytes: Size::new(123),
+        child_count: 0,
         children: vec![],
     };
 

--- a/src/main_test.rs
+++ b/src/main_test.rs
@@ -1,10 +1,10 @@
+use std::env;
+
 use crate::{
-    cli::{cli_command::CliCommand, view_command::ViewCommand},
-    parse_args, resolve_command, run,
+    parse_args, prepare_command, run,
     test_directory_utils::{create_test_directory_tree, delete_test_directory_tree},
     test_utils::TestOut,
 };
-use std::env;
 
 const BINARY_PATH: &str = "./space";
 
@@ -41,22 +41,18 @@ fn parse_args_given_non_interactive_returns_correct_args() -> anyhow::Result<()>
 }
 
 #[test]
-fn resolve_command_when_no_target_paths_specified_uses_current_dir() -> anyhow::Result<()> {
+fn prepare_command_when_no_target_paths_specified_uses_current_dir() -> anyhow::Result<()> {
     // Arrange
     let args = vec![BINARY_PATH.to_string()];
+    let args = parse_args(&args)?;
 
     // Act
-    let mut cli_command = resolve_command(&args)?;
-    cli_command.prepare()?;
+    let command = prepare_command(args)?;
 
     // Assert
-    let view_command = cli_command
-        .as_any()
-        .downcast_ref::<ViewCommand>()
-        .expect("Not a ViewCommand!");
     assert_eq!(
         Some(vec!(env::current_dir().unwrap())),
-        view_command.target_paths
+        command.target_paths
     );
 
     Ok(())

--- a/src/space_bench.rs
+++ b/src/space_bench.rs
@@ -1,0 +1,173 @@
+use anyhow::bail;
+use clap::{arg, ColorChoice, Parser};
+use cli::{cli_command::CliCommand, view_command::ViewCommand};
+use criterion::Criterion;
+use space_rs::SizeDisplayFormat;
+use std::{
+    io::{self, Write},
+    path::PathBuf,
+    time::Duration,
+};
+
+#[cfg(test)]
+#[path = "./space_bench_test.rs"]
+mod space_bench_test;
+
+#[cfg(test)]
+mod test_directory_utils;
+
+#[cfg(test)]
+mod test_utils;
+
+mod cli;
+
+pub(crate) const DEFAULT_SIZE_THRESHOLD_PERCENTAGE: u8 = 1;
+
+#[derive(Clone, Debug, Parser)]
+#[clap(
+    name = "space-bench",
+    version,
+    long_about =
+r#"The time to analyze and display the specified tree(s) will be benchmarked. This is useful for project
+contributors to quickly test and compare the performance impact of their changes against the previous release
+version. You would typically run this in the root of the space repo. Results are stored to
+./target/criterion and used for comparisons with previous runs."#,
+    after_help =
+r#"EXAMPLES:
+    $ space-bench path/to/file/or/dir
+    $ space-bench path/to/dir1 path/to/dir2
+    $ space-bench --size-threshold-percentage 5"#,
+    after_long_help =
+r#"EXAMPLES:
+    Benchmark using a single directory:
+    $ space-bench path/to/dir
+
+    Benchmark using multiple directories:
+    $ space-bench path/to/dir1 path/to/dir2
+
+    Benchmark using a single directory and with a relative size display filter of >= 5%:
+    $ space-bench path/to/dir --size-threshold-percentage 5
+
+    Benchmark using a single directory and with binary units rather than the default metric units:
+    $ space-bench path/to/dir --size-format binary"#,
+    color = ColorChoice::Never,
+)]
+struct CliArgs {
+    /// The path(s) to the target files or directories to view. If not supplied the current directory
+    /// will be used. Separate multiple paths using spaces.
+    #[arg(value_name = "TARGET PATH(S)", value_parser, num_args = 1.., value_delimiter = ' ')]
+    target_paths: Vec<PathBuf>,
+
+    /// The size threshold as a percentage of the total. Only items with a relative size greater or equal
+    /// to this percentage will be included.
+    #[arg(value_name = "PERCENTAGE", short = 's', long, default_value_t = DEFAULT_SIZE_THRESHOLD_PERCENTAGE, value_parser = clap::value_parser!(u8).range(0..=100))]
+    size_threshold_percentage: u8,
+
+    /// The format to use when a size value is displayed.
+    #[arg(short = 'f', long, value_enum, default_value_t = SizeDisplayFormat::Metric)]
+    size_display_format: SizeDisplayFormat,
+
+    /// The sample size for the benchmark.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(10..=1000))]
+    sample_size: u16,
+
+    /// The warmup time in seconds.
+    #[arg(long, default_value_t = 3, value_parser = clap::value_parser!(u16).range(1..=100))]
+    warmup_seconds: u16,
+
+    /// The measurement time in seconds.
+    #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u16).range(1..=100))]
+    measurement_seconds: u16,
+}
+
+pub struct BenchmarkCommand {
+    target_paths: Vec<PathBuf>,
+    size_display_format: SizeDisplayFormat,
+    size_threshold_percentage: u8,
+    sample_size: u16,
+    warmup_seconds: u16,
+    measurement_seconds: u16,
+    buffer: Vec<u8>,
+}
+
+impl BenchmarkCommand {
+    pub fn new(
+        target_paths: Vec<PathBuf>,
+        size_display_format: SizeDisplayFormat,
+        size_threshold_percentage: u8,
+        sample_size: u16,
+        warmup_seconds: u16,
+        measurement_seconds: u16,
+    ) -> Self {
+        BenchmarkCommand {
+            target_paths,
+            size_display_format,
+            size_threshold_percentage,
+            sample_size,
+            warmup_seconds,
+            measurement_seconds,
+            buffer: Vec::new(),
+        }
+    }
+
+    fn run(&mut self) -> anyhow::Result<()> {
+        let mut c = Criterion::default()
+            .significance_level(0.5)
+            .sample_size(self.sample_size.into())
+            .warm_up_time(Duration::from_secs(self.warmup_seconds.into()))
+            .measurement_time(Duration::from_secs(self.measurement_seconds.into()));
+
+        c.bench_function(&format!("{:?}", self.target_paths), |b| {
+            b.iter(|| {
+                ViewCommand::new(
+                    Some(self.target_paths.clone()),
+                    Some(self.size_display_format),
+                    self.size_threshold_percentage,
+                    true,
+                )
+                .prepare()
+                .unwrap()
+                .run(self)
+                .unwrap();
+            })
+        });
+        Ok(())
+    }
+}
+
+impl Write for BenchmarkCommand {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(not(test))]
+pub fn main() -> anyhow::Result<()> {
+    use std::env;
+    run(&env::args().collect::<Vec<_>>())?;
+    Ok(())
+}
+
+fn run(args: &[String]) -> anyhow::Result<()> {
+    let args = CliArgs::parse_from(args);
+    if args.target_paths.is_empty() {
+        bail!("Please specify at least one target path to use for benchmarking.");
+    }
+
+    BenchmarkCommand::new(
+        args.target_paths,
+        args.size_display_format,
+        args.size_threshold_percentage,
+        args.sample_size,
+        args.warmup_seconds,
+        args.measurement_seconds,
+    )
+    .run()?;
+
+    Ok(())
+}

--- a/src/space_bench_test.rs
+++ b/src/space_bench_test.rs
@@ -1,0 +1,38 @@
+use super::run;
+use crate::test_directory_utils::{create_test_directory_tree, delete_test_directory_tree};
+
+const BINARY_PATH: &str = "./space-bench";
+
+#[test]
+fn run_without_target_path_fails() {
+    // Arrange
+    let args = vec![BINARY_PATH.to_string()];
+
+    // Act
+    let result = run(&args);
+
+    // Assert
+    assert!(result.is_err());
+}
+
+#[test]
+fn run_with_target_path_succeeds() -> anyhow::Result<()> {
+    // Arrange
+    let temp_dir = create_test_directory_tree()?;
+    let args = vec![
+        BINARY_PATH.to_string(),
+        temp_dir.display().to_string(),
+        "--warmup-seconds".to_string(),
+        "1".to_string(),
+        "--measurement-seconds".to_string(),
+        "1".to_string(),
+    ];
+
+    // Act
+    run(&args)?;
+
+    // Assert
+    delete_test_directory_tree(&temp_dir);
+
+    Ok(())
+}


### PR DESCRIPTION
## Describe your changes
- Removes the show-timing arg and replace that with a new binary `space-bench` which can be used by maintainers and workflows to compare perf against previous version.
- Small navigation improvement where the `+`  key now expands the selected item if it is collapsed and shows the children as collapsed.

## PR requirements
- [x] I have followed the guidelines in the [Contribution Guide](../CONTRIBUTING.md#general-guidelines) document.
- [x] I have checked that there aren't other open [Pull Requests](https://github.com/emilevr/space/pulls) for the same update/change.
- [x] I have confirmed locally that there are no linting issues.
- [x] I have confirmed that all tests pass locally.
- [x] I have confirmed that my changes do not negatively impact performance by manually comparing before and
      after performance against a suitable local directory tree.
- [x] I have confirmed that code coverage has not regressed as a result of my changes.