### PR TITLE
Add support for skins and use for better color capability handling across terminals

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 ## Describe your changes
+> **TIP**: Use the `Preview` tab to more easily read these notes. Remember to delete all the notes before you submit the PR.
+> :construction_worker: Use bullet points to list the major changes or any change you feel is relevant.
+> :construction_worker: DELETE THIS NOTE
 -
 
 ## Issue ticket number(s) and link(s)
 > :bulb: List any linked issues here by using the keywords and format described [here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
-> :construction_worker: DELETE THIS NOTE
-
--
-
 > :construction_worker: Delete this whole section if this PR is not related to any open issues.
 > :construction_worker: DELETE THIS NOTE
+-
 
 ## PR requirements
 > :exclamation: The following requirements must be met otherwise this PR will not be accepted:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -37,7 +37,11 @@ jobs:
             tmux new-session -d -s tests -x 200 -y 20
 
             # Send the command to run the tests with code coverage.
-            tmux send-keys -t tests 'buildit coverage --include-ignored ; tmux wait -S tests-finished' Enter
+            #   - We exclude src/main.rs as it is fully covered, but some of the non-test code is incorrectly
+            #     covered as well.
+            #   - We exlude src/logging.rs as it is fully covered but the percentage is calculated
+            #     incorrectly by grcov.
+            tmux send-keys -t tests 'buildit coverage --include-ignored --exclude-files src/main.rs src/logging.rs ; tmux wait -S tests-finished' Enter
 
             # Wait for the tests-finished signal.
             tmux wait-for tests-finished

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,5 @@
 name: Lint
 on:
-  pull_request:
   push:
     branches-ignore:
       - ' '

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,5 @@
 name: Test
 on:
-  pull_request:
   push:
     branches-ignore:
       - ' '

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,18 +240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "coolor"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6ac2088e244fd157068daf566f17f7b46d5c543273582bc8b2875233bdfb86"
-
-[[package]]
-name = "coolor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce3e41909f18d5860fe1e6699651fcca2cb2576ee68c6984c93c2b26d059ea"
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,7 +301,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
+ "memoffset",
  "scopeguard",
 ]
 
@@ -324,22 +312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
 ]
 
 [[package]]
@@ -771,15 +743,6 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -807,19 +770,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -953,7 +903,7 @@ checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
  "bitflags 2.4.0",
  "cassowary",
- "crossterm 0.27.0",
+ "crossterm",
  "indoc",
  "itertools 0.11.0",
  "paste",
@@ -1249,9 +1199,8 @@ dependencies = [
  "bumpalo",
  "bumpalo-herd",
  "clap",
- "coolor 0.8.0",
  "criterion",
- "crossterm 0.27.0",
+ "crossterm",
  "dirs",
  "id-arena",
  "log",
@@ -1263,7 +1212,6 @@ dependencies = [
  "rstest",
  "serde",
  "serde_yaml 0.9.25",
- "terminal-light",
  "unicode-segmentation",
  "uuid",
 ]
@@ -1316,18 +1264,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "terminal-light"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9077b39afb70f12391e4c1fcf46319999cfc32b45d605a668052bc4d1b4511af"
-dependencies = [
- "coolor 0.5.1",
- "crossterm 0.23.2",
- "thiserror",
- "xterm-query",
 ]
 
 [[package]]
@@ -1612,17 +1548,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "xterm-query"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec02abe9c7efbcb010adc0d90bc4a054653477cd4a3eb8eef5a689799c146a13"
-dependencies = [
- "mio",
- "nix",
- "thiserror",
-]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "coolor"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6ac2088e244fd157068daf566f17f7b46d5c543273582bc8b2875233bdfb86"
+
+[[package]]
+name = "coolor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce3e41909f18d5860fe1e6699651fcca2cb2576ee68c6984c93c2b26d059ea"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,7 +313,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.9.0",
  "scopeguard",
 ]
 
@@ -312,6 +324,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
 ]
 
 [[package]]
@@ -743,6 +771,15 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
@@ -770,6 +807,19 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
+dependencies = [
+ "bitflags 1.3.2",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -903,7 +953,7 @@ checksum = "2e2e4cd95294a85c3b4446e63ef054eea43e0205b1fd60120c16b74ff7ff96ad"
 dependencies = [
  "bitflags 2.4.0",
  "cassowary",
- "crossterm",
+ "crossterm 0.27.0",
  "indoc",
  "itertools 0.11.0",
  "paste",
@@ -1199,8 +1249,9 @@ dependencies = [
  "bumpalo",
  "bumpalo-herd",
  "clap",
+ "coolor 0.8.0",
  "criterion",
- "crossterm",
+ "crossterm 0.27.0",
  "dirs",
  "id-arena",
  "log",
@@ -1212,6 +1263,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_yaml 0.9.25",
+ "terminal-light",
  "unicode-segmentation",
  "uuid",
 ]
@@ -1264,6 +1316,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal-light"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9077b39afb70f12391e4c1fcf46319999cfc32b45d605a668052bc4d1b4511af"
+dependencies = [
+ "coolor 0.5.1",
+ "crossterm 0.23.2",
+ "thiserror",
+ "xterm-query",
 ]
 
 [[package]]
@@ -1548,6 +1612,17 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "xterm-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec02abe9c7efbcb010adc0d90bc4a054653477cd4a3eb8eef5a689799c146a13"
+dependencies = [
+ "mio",
+ "nix",
+ "thiserror",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +382,12 @@ dependencies = [
  "redox_users",
  "windows-sys",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -411,10 +423,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -667,6 +694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +806,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +941,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "predicates"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools 0.10.5",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -1206,6 +1302,7 @@ dependencies = [
  "log",
  "log4rs",
  "memory-stats",
+ "mockall",
  "ratatui",
  "rayon",
  "regex",
@@ -1265,6 +1362,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ bench = ["clap/derive", "crossterm", "dirs", "ratatui", "criterion"]
 [dependencies]
 anyhow = "^1.0.72"
 clap = { version = "^4.3.21", optional = true }
-coolor = "^0.8.0"
 criterion = { version = "^0.5.1", default-features = false, features = [], optional = true }
 crossterm = { version = "^0.27.0", optional = true }
 dirs = { version = "^5.0.1", optional = true }
@@ -65,7 +64,6 @@ ratatui = { version = "^0.23.0", default-features = false, features = ["crosster
 rayon = "^1.7.0"
 serde = { version = "^1.0.188", features = ["derive"], optional = true }
 serde_yaml = { version = "^0.9.25", optional = true }
-terminal-light = "^1.1.1"
 unicode-segmentation = "^1.10.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ bench = ["clap/derive", "crossterm", "dirs", "ratatui", "criterion"]
 [dependencies]
 anyhow = "^1.0.72"
 clap = { version = "^4.3.21", optional = true }
+coolor = "^0.8.0"
 criterion = { version = "^0.5.1", default-features = false, features = [], optional = true }
 crossterm = { version = "^0.27.0", optional = true }
 dirs = { version = "^5.0.1", optional = true }
@@ -64,6 +65,7 @@ ratatui = { version = "^0.23.0", default-features = false, features = ["crosster
 rayon = "^1.7.0"
 serde = { version = "^1.0.188", features = ["derive"], optional = true }
 serde_yaml = { version = "^0.9.25", optional = true }
+terminal-light = "^1.1.1"
 unicode-segmentation = "^1.10.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ bumpalo-herd = "^0.1.2"
 criterion = "^0.5.1"
 id-arena = { version = "^2.2.1", features = ["rayon"] }
 memory-stats = "^1.1.0"
+mockall = "0.11.4"
 regex = "^1.9.5"
 rstest = "^0.18.2"
 uuid = { version = "^1.4.1", features = ["v4"] }

--- a/buildit/src/benchmark.rs
+++ b/buildit/src/benchmark.rs
@@ -13,7 +13,8 @@ use crate::command::BuildItCommand;
 
 #[derive(Args, Debug)]
 pub struct BenchmarkCommandArgs {
-    /// One or more optional benchmarks to run. If not specified then all benchmarks will be run.
+    /// One or more optional benchmarks to run. If not specified then all benchmarks will be run. Separate
+    /// multiple names using spaces.
     #[arg(long = "bench-names", value_parser, num_args = 1.., value_delimiter = ' ')]
     pub bench_names: Option<Vec<String>>,
 }

--- a/buildit/src/version.rs
+++ b/buildit/src/version.rs
@@ -52,7 +52,7 @@ pub struct VersionCommandArgs {
     pub pre_release_name: String,
 
     /// One or more glob patterns used to find Cargo.toml manifests, which will be updated to the calculated
-    /// version.
+    /// version.  Separate multiple globs using spaces.
     #[arg(
         short = 'm',
         long = "manifest-globs",

--- a/src/cli/environment.rs
+++ b/src/cli/environment.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+use mockall::{automock, predicate::*};
+use std::{
+    env::{self, VarError},
+    io::{self},
+    ops::Deref,
+    path::PathBuf,
+};
+
+#[cfg_attr(test, automock)]
+pub(crate) trait EnvServiceTrait {
+    fn var(&self, key: &str) -> Result<String, VarError>;
+    fn current_dir(&self) -> io::Result<PathBuf>;
+}
+
+#[derive(Default)]
+pub(crate) struct DefaultEnvService {}
+
+impl EnvServiceTrait for DefaultEnvService {
+    fn var(&self, key: &str) -> Result<String, VarError> {
+        env::var(key)
+    }
+
+    fn current_dir(&self) -> io::Result<PathBuf> {
+        env::current_dir()
+    }
+}
+
+impl EnvServiceTrait for Box<dyn EnvServiceTrait> {
+    fn var(&self, key: &str) -> Result<String, VarError> {
+        self.deref().var(key)
+    }
+
+    fn current_dir(&self) -> io::Result<PathBuf> {
+        self.deref().current_dir()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{DefaultEnvService, EnvServiceTrait};
+
+    #[test]
+    fn default_env_service_current_dir_returns_env_current_dir() {
+        // Arrange
+        let service = DefaultEnvService::default();
+
+        // Act
+        let current_dir = service
+            .current_dir()
+            .expect("Should be able to get current dir via service");
+
+        // Assert
+        let env_current_dir =
+            std::env::current_dir().expect("Should be able to get current dir via env");
+        assert_eq!(env_current_dir, current_dir);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,5 @@
 pub mod cli_command;
+pub mod environment;
 pub mod tui;
 pub mod view_command;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ mod crossterm_input_event_source;
 
 mod input_event_source;
 mod row_item;
+mod skin;
 mod view_state;
 
 #[cfg(test)]

--- a/src/cli/skin.rs
+++ b/src/cli/skin.rs
@@ -20,14 +20,14 @@ impl Default for Skin {
     fn default() -> Self {
         // The default dark mode skin
         Self {
-            table_header_bg_color: Color::Rgb(64, 64, 176),
-            table_header_fg_color: Color::White,
             title_fg_color: Color::White,
             title_bg_color: Color::Rgb(64, 64, 64),
             version_fg_color: Color::Rgb(192, 192, 192),
+            table_header_bg_color: Color::Rgb(64, 64, 176),
+            table_header_fg_color: Color::White,
             value_fg_color: Color::Rgb(88, 144, 255),
             key_help_danger_bg_color: Color::Rgb(192, 64, 64),
-            key_help_key_fg_color: Color::Rgb(88, 144, 255),
+            key_help_key_fg_color: Color::Rgb(192, 192, 192),
             item_type_directory_symbol: '📁',
             item_type_file_symbol: '📄',
             item_type_symbolic_link_symbol: '🔗',

--- a/src/cli/skin.rs
+++ b/src/cli/skin.rs
@@ -1,4 +1,4 @@
-use ratatui::style::Color;
+use ratatui::style::{Color, Modifier, Style};
 
 #[derive(Clone, Copy)]
 pub(crate) struct Skin {
@@ -7,7 +7,9 @@ pub(crate) struct Skin {
     pub(crate) version_fg_color: Color,
     pub(crate) table_header_bg_color: Color,
     pub(crate) table_header_fg_color: Color,
-    pub(crate) value_fg_color: Color,
+    pub(crate) value_fg_color: Option<Color>,
+    pub(crate) value_style_invert: bool,
+    pub(crate) delete_warning_text_fg_color: Color,
     pub(crate) key_help_danger_bg_color: Color,
     pub(crate) key_help_key_fg_color: Color,
     pub(crate) item_type_directory_symbol: char,
@@ -25,7 +27,9 @@ impl Default for Skin {
             version_fg_color: Color::Rgb(192, 192, 192),
             table_header_bg_color: Color::Rgb(64, 64, 176),
             table_header_fg_color: Color::White,
-            value_fg_color: Color::Rgb(88, 144, 255),
+            value_fg_color: Some(Color::Rgb(88, 144, 255)),
+            value_style_invert: false,
+            delete_warning_text_fg_color: Color::Rgb(255, 165, 0),
             key_help_danger_bg_color: Color::Rgb(192, 64, 64),
             key_help_key_fg_color: Color::Rgb(192, 192, 192),
             item_type_directory_symbol: '📁',
@@ -33,5 +37,18 @@ impl Default for Skin {
             item_type_symbolic_link_symbol: '🔗',
             item_type_unknown_symbol: '❓',
         }
+    }
+}
+
+impl Skin {
+    pub fn value_style(&self) -> Style {
+        let mut style = Style::default();
+        if let Some(fg) = self.value_fg_color {
+            style = style.fg(fg);
+        }
+        if self.value_style_invert {
+            style = style.add_modifier(Modifier::REVERSED);
+        }
+        style
     }
 }

--- a/src/cli/skin.rs
+++ b/src/cli/skin.rs
@@ -1,5 +1,9 @@
 use ratatui::style::{Color, Modifier, Style};
 
+#[cfg(test)]
+#[path = "./skin_test.rs"]
+mod skin_test;
+
 #[derive(Clone, Copy)]
 pub(crate) struct Skin {
     pub(crate) title_fg_color: Color,
@@ -8,7 +12,7 @@ pub(crate) struct Skin {
     pub(crate) table_header_bg_color: Color,
     pub(crate) table_header_fg_color: Color,
     pub(crate) value_fg_color: Option<Color>,
-    pub(crate) value_style_invert: bool,
+    pub(crate) value_style_reversed: bool,
     pub(crate) delete_warning_text_fg_color: Color,
     pub(crate) key_help_danger_bg_color: Color,
     pub(crate) key_help_key_fg_color: Color,
@@ -28,7 +32,7 @@ impl Default for Skin {
             table_header_bg_color: Color::Rgb(64, 64, 176),
             table_header_fg_color: Color::White,
             value_fg_color: Some(Color::Rgb(88, 144, 255)),
-            value_style_invert: false,
+            value_style_reversed: false,
             delete_warning_text_fg_color: Color::Rgb(255, 165, 0),
             key_help_danger_bg_color: Color::Rgb(192, 64, 64),
             key_help_key_fg_color: Color::Rgb(192, 192, 192),
@@ -46,7 +50,7 @@ impl Skin {
         if let Some(fg) = self.value_fg_color {
             style = style.fg(fg);
         }
-        if self.value_style_invert {
+        if self.value_style_reversed {
             style = style.add_modifier(Modifier::REVERSED);
         }
         style

--- a/src/cli/skin.rs
+++ b/src/cli/skin.rs
@@ -1,0 +1,35 @@
+use ratatui::style::Color;
+
+#[derive(Clone, Copy)]
+pub(crate) struct Skin {
+    pub(crate) table_header_bg_color: Color,
+    pub(crate) table_header_fg_color: Color,
+    pub(crate) title_fg_color: Color,
+    pub(crate) title_bg_color: Color,
+    pub(crate) value_fg_color: Color,
+    pub(crate) key_help_danger_bg_color: Color,
+    pub(crate) key_help_key_fg_color: Color,
+    pub(crate) item_type_directory_symbol: char,
+    pub(crate) item_type_file_symbol: char,
+    pub(crate) item_type_symbolic_link_symbol: char,
+    pub(crate) item_type_unknown_symbol: char,
+}
+
+impl Default for Skin {
+    fn default() -> Self {
+        // The default dark mode skin
+        Self {
+            table_header_bg_color: Color::Rgb(64, 64, 192),
+            table_header_fg_color: Color::White,
+            title_fg_color: Color::White,
+            title_bg_color: Color::Rgb(64, 64, 64),
+            value_fg_color: Color::Rgb(88, 144, 255),
+            key_help_danger_bg_color: Color::Rgb(192, 64, 64),
+            key_help_key_fg_color: Color::Rgb(88, 144, 255),
+            item_type_directory_symbol: '📁',
+            item_type_file_symbol: '📄',
+            item_type_symbolic_link_symbol: '🔗',
+            item_type_unknown_symbol: '❓',
+        }
+    }
+}

--- a/src/cli/skin.rs
+++ b/src/cli/skin.rs
@@ -2,10 +2,11 @@ use ratatui::style::Color;
 
 #[derive(Clone, Copy)]
 pub(crate) struct Skin {
-    pub(crate) table_header_bg_color: Color,
-    pub(crate) table_header_fg_color: Color,
     pub(crate) title_fg_color: Color,
     pub(crate) title_bg_color: Color,
+    pub(crate) version_fg_color: Color,
+    pub(crate) table_header_bg_color: Color,
+    pub(crate) table_header_fg_color: Color,
     pub(crate) value_fg_color: Color,
     pub(crate) key_help_danger_bg_color: Color,
     pub(crate) key_help_key_fg_color: Color,
@@ -19,10 +20,11 @@ impl Default for Skin {
     fn default() -> Self {
         // The default dark mode skin
         Self {
-            table_header_bg_color: Color::Rgb(64, 64, 192),
+            table_header_bg_color: Color::Rgb(64, 64, 176),
             table_header_fg_color: Color::White,
             title_fg_color: Color::White,
             title_bg_color: Color::Rgb(64, 64, 64),
+            version_fg_color: Color::Rgb(192, 192, 192),
             value_fg_color: Color::Rgb(88, 144, 255),
             key_help_danger_bg_color: Color::Rgb(192, 64, 64),
             key_help_key_fg_color: Color::Rgb(88, 144, 255),

--- a/src/cli/skin_test.rs
+++ b/src/cli/skin_test.rs
@@ -1,0 +1,62 @@
+use super::Skin;
+use ratatui::style::{Modifier, Style};
+
+#[test]
+fn value_style_with_no_fg_does_not_set_fg() {
+    // Arrange
+    let mut skin = Skin::default();
+    skin.value_fg_color = None;
+
+    // Act
+    let style = skin.value_style();
+
+    // Assert
+    assert_eq!(Style::default(), style);
+}
+
+#[test]
+fn value_style_with_fg_sets_fg() {
+    // Arrange
+    let skin = Skin::default();
+
+    // Act
+    let style = skin.value_style();
+
+    // Assert
+    assert_eq!(Style::default().fg(skin.value_fg_color.unwrap()), style);
+}
+
+#[test]
+fn default_skin_value_style_does_not_reverse() {
+    // Arrange
+    let skin = Skin::default();
+
+    // Act
+    let style = skin.value_style();
+
+    // Assert
+    assert_ne!(
+        Style::default()
+            .fg(skin.value_fg_color.unwrap())
+            .add_modifier(Modifier::REVERSED),
+        style
+    );
+}
+
+#[test]
+fn value_style_with_reverse_applies_reverse() {
+    // Arrange
+    let mut skin = Skin::default();
+    skin.value_style_reversed = true;
+
+    // Act
+    let style = skin.value_style();
+
+    // Assert
+    assert_eq!(
+        Style::default()
+            .fg(skin.value_fg_color.unwrap())
+            .add_modifier(Modifier::REVERSED),
+        style
+    );
+}

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -1,6 +1,7 @@
 use super::{
     input_event_source::InputEventSource,
     row_item::RowItemType,
+    skin::Skin,
     view_state::{
         get_excl_percentage_column_width, ViewState, APPARENT_SIZE_COLUMN_WIDTH,
         EXPAND_INDICATOR_COLUMN_WIDTH, INCL_PERCENTAGE_COLUMN_WIDTH,
@@ -33,35 +34,6 @@ use std::{
 mod tui_test;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-#[cfg(target_os = "macos")]
-const KEY_HELP_KEY_FG_COLOR: Color = Color::Rgb(0, 0, 64);
-#[cfg(not(target_os = "macos"))]
-const KEY_HELP_KEY_FG_COLOR: Color = Color::Rgb(88, 144, 255);
-
-#[cfg(target_os = "macos")]
-const TABLE_HEADER_BG_COLOR: Color = Color::Rgb(64, 64, 64);
-#[cfg(not(target_os = "macos"))]
-const TABLE_HEADER_BG_COLOR: Color = Color::Rgb(64, 64, 192);
-
-#[cfg(target_os = "macos")]
-const TABLE_HEADER_FG_COLOR: Color = Color::Rgb(0, 0, 0);
-#[cfg(not(target_os = "macos"))]
-const TABLE_HEADER_FG_COLOR: Color = Color::White;
-
-const DANGER_BG_COLOR: Color = Color::Rgb(192, 64, 64);
-
-#[cfg(target_os = "macos")]
-const TITLE_FG_COLOR: Color = Color::Black;
-#[cfg(not(target_os = "macos"))]
-const TITLE_FG_COLOR: Color = Color::White;
-
-#[cfg(target_os = "macos")]
-const TITLE_BG_COLOR: Color = Color::Rgb(128, 128, 128);
-#[cfg(not(target_os = "macos"))]
-const TITLE_BG_COLOR: Color = Color::Rgb(64, 64, 64);
-
-const VALUE_FG_COLOR: Color = Color::Rgb(88, 144, 255);
 
 pub(crate) const HELP_KEY: char = '?';
 pub(crate) const QUIT_KEY_1: char = 'q';
@@ -97,6 +69,7 @@ pub(crate) fn render<W: Write, I: InputEventSource>(
     view_state: &mut ViewState,
     writer: &mut W,
     input_event_source: &mut I,
+    skin: &Skin,
 ) -> anyhow::Result<()> {
     enable_raw_mode()?;
 
@@ -104,7 +77,7 @@ pub(crate) fn render<W: Write, I: InputEventSource>(
     let backend = CrosstermBackend::new(writer);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = render_loop(&mut terminal, view_state, input_event_source);
+    let result = render_loop(&mut terminal, view_state, input_event_source, skin);
 
     disable_raw_mode()?;
     execute!(
@@ -141,9 +114,10 @@ fn render_loop<B: Backend, I: InputEventSource>(
     terminal: &mut Terminal<B>,
     view_state: &mut ViewState,
     input_event_source: &mut I,
+    skin: &Skin,
 ) -> anyhow::Result<()> {
     loop {
-        terminal.draw(|f| create_frame(f, view_state))?;
+        terminal.draw(|f| create_frame(f, view_state, skin))?;
 
         if let Event::Key(KeyEvent {
             code,
@@ -213,10 +187,14 @@ fn render_loop<B: Backend, I: InputEventSource>(
                     KeyCode::PageDown => view_state.next(view_state.visible_height),
                     KeyCode::Home => view_state.first(),
                     KeyCode::End => view_state.last(),
-                    #[rustfmt::skip]
-                    KeyCode::Char(COLLAPSE_SELECTED_CHILDREN_KEY) | KeyCode::Char(COLLAPSE_SELECTED_CHILDREN_KEY_ALT) => { view_state.collapse_selected_children() },
-                    #[rustfmt::skip]
-                    KeyCode::Char(EXPAND_SELECTED_CHILDREN_KEY) | KeyCode::Char(EXPAND_SELECTED_CHILDREN_KEY_ALT) => { view_state.expand_selected_children() },
+                    KeyCode::Char(COLLAPSE_SELECTED_CHILDREN_KEY)
+                    | KeyCode::Char(COLLAPSE_SELECTED_CHILDREN_KEY_ALT) => {
+                        view_state.collapse_selected_children()
+                    }
+                    KeyCode::Char(EXPAND_SELECTED_CHILDREN_KEY)
+                    | KeyCode::Char(EXPAND_SELECTED_CHILDREN_KEY_ALT) => {
+                        view_state.expand_selected_children()
+                    }
                     _ => {}
                 }
             }
@@ -224,7 +202,7 @@ fn render_loop<B: Backend, I: InputEventSource>(
     }
 }
 
-fn create_frame<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState) {
+fn create_frame<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState, skin: &Skin) {
     let view_height = f.size().height;
     let table_height = view_height - 1; // Subract one for the help header.
 
@@ -240,29 +218,25 @@ fn create_frame<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState) {
         .constraints([Constraint::Length(width - 1), Constraint::Length(1)].as_ref())
         .split(vertical_rects[1]);
 
-    let title_style = Style::default().fg(TITLE_FG_COLOR).bg(TITLE_BG_COLOR);
-
-    render_title_bar(f, view_state, &vertical_rects[0], title_style);
-    render_table(f, view_state, &horizontal_rects[0]);
-    render_vertical_scrollbar(f, view_state, &horizontal_rects[1], title_style);
+    render_title_bar(f, view_state, &vertical_rects[0], skin);
+    render_table(f, view_state, &horizontal_rects[0], skin);
+    render_vertical_scrollbar(f, view_state, &horizontal_rects[1], skin);
 
     if view_state.show_help {
-        render_help(f);
+        render_help(f, skin);
     } else if view_state.show_delete_dialog {
         if view_state.accepted_license_terms {
-            render_delete_dialog(f, view_state);
+            render_delete_dialog(f, view_state, skin);
         } else {
-            render_accept_license_terms_dialog(f);
+            render_accept_license_terms_dialog(f, skin);
         }
     }
 }
 
-fn render_title_bar<B: Backend>(
-    f: &mut Frame<B>,
-    data: &ViewState,
-    area: &Rect,
-    title_style: Style,
-) {
+fn render_title_bar<B: Backend>(f: &mut Frame<B>, data: &ViewState, area: &Rect, skin: &Skin) {
+    let title_style = Style::default()
+        .fg(skin.title_fg_color)
+        .bg(skin.title_bg_color);
     let version_style = title_style;
 
     let title = "Space";
@@ -274,7 +248,7 @@ fn render_title_bar<B: Backend>(
         - 3  // Subtract 3 for the column separators
         - 1; // Subtract 1 to account for table scrollbar.
 
-    let (key_help, available_width) = get_key_help(title_style, available_width);
+    let (key_help, available_width) = get_key_help(available_width, skin);
 
     let key_help_len = key_help.width();
     let title_cells = [
@@ -309,10 +283,14 @@ fn render_title_bar<B: Backend>(
 }
 
 /// Add only as many key help entries as we have space for. We add the more important ones first.
-fn get_key_help<'a>(title_style: Style, available_width: i32) -> (Line<'a>, i32) {
+fn get_key_help<'a>(available_width: i32, skin: &Skin) -> (Line<'a>, i32) {
     let mut available_width = available_width;
-    let key_style = title_style.fg(KEY_HELP_KEY_FG_COLOR);
-    let key_help_style = title_style;
+    let key_style = Style::default()
+        .bg(skin.title_bg_color)
+        .fg(skin.key_help_key_fg_color);
+    let key_help_style = Style::default()
+        .bg(skin.title_bg_color)
+        .fg(skin.title_fg_color);
 
     #[rustfmt::skip]
     let all_key_help = vec![
@@ -340,10 +318,15 @@ fn get_key_help<'a>(title_style: Style, available_width: i32) -> (Line<'a>, i32)
     (Line::from(key_help), available_width)
 }
 
-fn render_table<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState, area: &Rect) {
+fn render_table<B: Backend>(
+    f: &mut Frame<B>,
+    view_state: &mut ViewState,
+    area: &Rect,
+    skin: &Skin,
+) {
     let table_header_style = Style::default()
-        .bg(TABLE_HEADER_BG_COLOR)
-        .fg(TABLE_HEADER_FG_COLOR);
+        .bg(skin.table_header_bg_color)
+        .fg(skin.table_header_fg_color);
     let selected_style = Style::default().add_modifier(Modifier::REVERSED);
 
     let table_selected_index = view_state.table_selected_index;
@@ -379,7 +362,7 @@ fn render_vertical_scrollbar<B: Backend>(
     f: &mut Frame<B>,
     data: &mut ViewState,
     area: &Rect,
-    title_style: Style,
+    skin: &Skin,
 ) {
     // The content length must be the total number of rows minus the number of visible rows.
     let content_length = if data.displayable_item_count > data.visible_height {
@@ -402,13 +385,17 @@ fn render_vertical_scrollbar<B: Backend>(
                 begin: "▲",
                 end: "▼",
             })
-            .style(title_style),
+            .style(
+                Style::default()
+                    .bg(skin.title_bg_color)
+                    .fg(skin.title_fg_color),
+            ),
         *area,
         &mut vertical_scroll_state,
     );
 }
 
-fn render_help<B: Backend>(f: &mut Frame<B>) {
+fn render_help<B: Backend>(f: &mut Frame<B>, skin: &Skin) {
     let block = Block::default().title("Help").borders(Borders::ALL);
     let mut area = f.size();
     f.render_widget(Clear, area); // Clear out the background
@@ -417,9 +404,11 @@ fn render_help<B: Backend>(f: &mut Frame<B>) {
     contract_area(&mut area, 2, 2);
 
     let key_style = Style::default()
-        .fg(TITLE_FG_COLOR)
-        .bg(TABLE_HEADER_BG_COLOR);
-    let danger_key_style = Style::default().fg(TITLE_FG_COLOR).bg(DANGER_BG_COLOR);
+        .fg(skin.title_fg_color)
+        .bg(skin.table_header_bg_color);
+    let danger_key_style = Style::default()
+        .fg(skin.title_fg_color)
+        .bg(skin.key_help_danger_bg_color);
     let section_header_style = Style::default().add_modifier(Modifier::BOLD);
 
     let key_column_size: usize = 11;
@@ -723,9 +712,9 @@ macro_rules! measure_height {
     }};
 }
 
-fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState) {
+fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState, skin: &Skin) {
     if let Some(selected_item) = view_state.get_selected_item() {
-        let value_style = Style::default().fg(VALUE_FG_COLOR);
+        let value_style = Style::default().fg(skin.value_fg_color);
         let selected_item_ref = selected_item.borrow();
         let is_dir = selected_item_ref.item_type == RowItemType::Directory;
 
@@ -799,8 +788,8 @@ fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState
     }
 }
 
-fn render_accept_license_terms_dialog<B: Backend>(f: &mut Frame<B>) {
-    let value_style = Style::default().fg(VALUE_FG_COLOR);
+fn render_accept_license_terms_dialog<B: Backend>(f: &mut Frame<B>, skin: &Skin) {
+    let value_style = Style::default().fg(skin.value_fg_color);
     let bold_style = Style::default().add_modifier(Modifier::BOLD);
 
     #[rustfmt::skip]

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -237,7 +237,9 @@ fn render_title_bar<B: Backend>(f: &mut Frame<B>, data: &ViewState, area: &Rect,
     let title_style = Style::default()
         .fg(skin.title_fg_color)
         .bg(skin.title_bg_color);
-    let version_style = title_style;
+    let version_style = Style::default()
+        .fg(skin.version_fg_color)
+        .bg(skin.title_bg_color);
 
     let title = "Space";
     let version_display = format!("v{VERSION}");

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -17,7 +17,7 @@ use crossterm::{
 use ratatui::{
     layout::{Constraint, Layout},
     prelude::*,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     widgets::{
         Block, Borders, Cell, Clear, Padding, Paragraph, Row, Scrollbar, ScrollbarOrientation,
         ScrollbarState, Table, TableState, Widget, Wrap,
@@ -716,7 +716,7 @@ macro_rules! measure_height {
 
 fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState, skin: &Skin) {
     if let Some(selected_item) = view_state.get_selected_item() {
-        let value_style = Style::default().fg(skin.value_fg_color);
+        let value_style = skin.value_style();
         let selected_item_ref = selected_item.borrow();
         let is_dir = selected_item_ref.item_type == RowItemType::Directory;
 
@@ -755,7 +755,7 @@ fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState
                     } else {
                         "".into()
                     }),
-                Style::default().fg(Color::Rgb(255, 165, 0)),
+                Style::default().fg(skin.delete_warning_text_fg_color),
             )),
             Line::default(),
             Line::from(vec![
@@ -779,7 +779,6 @@ fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState
                     .borders(Borders::ALL)
                     .padding(Padding::uniform(1)),
             )
-            .style(Style::default().fg(Color::White))
             .alignment(Alignment::Center)
             .wrap(Wrap { trim: true });
 
@@ -791,7 +790,7 @@ fn render_delete_dialog<B: Backend>(f: &mut Frame<B>, view_state: &mut ViewState
 }
 
 fn render_accept_license_terms_dialog<B: Backend>(f: &mut Frame<B>, skin: &Skin) {
-    let value_style = Style::default().fg(skin.value_fg_color);
+    let value_style = skin.value_style();
     let bold_style = Style::default().add_modifier(Modifier::BOLD);
 
     #[rustfmt::skip]
@@ -841,7 +840,6 @@ r#"By accepting, you agree to be bound by the terms of the MIT License. You can 
                 .borders(Borders::ALL)
                 .padding(Padding::uniform(1)),
         )
-        .style(Style::default().fg(Color::White))
         .alignment(Alignment::Left)
         .wrap(Wrap { trim: true });
 

--- a/src/cli/tui_test.rs
+++ b/src/cli/tui_test.rs
@@ -85,6 +85,9 @@ fn render_outputs_full_path_as_first_row_with_100_percent_size() -> anyhow::Resu
     )?;
 
     // Assert
+    // NOTE: If this test fails locally then make sure that the console window where this is running is wide
+    //       enough for the path to not be chopped off. On the build agent a virtual terminal 125 characters
+    //       wide is used.
     let regex_safe_path = view_state.visible_row_items[0]
         .borrow()
         .path_segment
@@ -226,11 +229,11 @@ fn render_with_cancelled_delete_does_not_delete_item(
 #[ignore]
 #[case(0f32, 0, "", 0)] // First item
 #[ignore]
-#[case(0f32, 3, "1.2", 24)] // File
+#[case(0f32, 3, "1.2", 28)] // File
 #[ignore]
-#[case(0f32, 4, "1.3", 21)] // Directory
+#[case(0f32, 4, "1.3", 25)] // Directory
 #[ignore]
-#[case(0.1f32, 4, "1.3", 21)] // Directory, with 10% size threshold fraction.
+#[case(0.1f32, 4, "1.3", 25)] // Directory, with 10% size threshold fraction.
 fn render_with_confirmed_delete_deletes_selected_item(
     #[case] size_threshold_fraction: f32,
     #[case] down_count: usize,
@@ -309,9 +312,9 @@ fn render_with_confirmed_delete_deletes_selected_item(
 #[ignore]
 #[case(23, 22, "1")] // down x23 to 1.9 + 22x up -> 1 selected
 #[ignore]
-#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 1, 0, "1.10")] // down number of items in tree -> 1.10 selected
+#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 1, 0, "1.12.1")] // down number of items in tree -> 1.12.1 selected
 #[ignore]
-#[case(TEST_DIRECTORY_TREE_ITEM_COUNT, 0, "1.10")] // down more than number of items in tree -> 1.10 selected
+#[case(TEST_DIRECTORY_TREE_ITEM_COUNT, 0, "1.12.1")] // down more than number of items in tree -> 1.12.1 selected
 fn render_with_navigation_input_selects_correct_item(
     #[case] down_count: usize,
     #[case] up_count: usize,
@@ -363,11 +366,11 @@ fn render_with_navigation_input_selects_correct_item(
 #[ignore]
 #[case(6, 0, 0, 1, "")] // down to 1st item on 2nd page + page up -> first item selected
 #[ignore]
-#[case(11, 0, TEST_DIRECTORY_TREE_ITEM_COUNT, 0, "1.10")] // down to 1.5.2 + page down xTEST_DIRECTORY_TREE_ITEM_COUNT -> 1.10 selected
+#[case(11, 0, TEST_DIRECTORY_TREE_ITEM_COUNT, 0, "1.12.1")] // down to 1.5.2 + page down xTEST_DIRECTORY_TREE_ITEM_COUNT -> 1.12.1 selected
 #[ignore]
-#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 2, 0, 1, 0, "1.10")] // down to 1.9 + page down -> 1.10 selected
+#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 2, 0, 1, 0, "1.12.1")] // down to 1.9 + page down -> 1.12.1 selected
 #[ignore]
-#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 1, 0, 1, 0, "1.10")] // down to 1.10 + page down -> 1.10 selected
+#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 1, 0, 1, 0, "1.12.1")] // down to 1.12.1 + page down -> 1.12.1 selected
 fn render_with_page_up_or_down_navigation_input_selects_correct_item(
     #[case] down_count: usize,
     #[case] up_count: usize,
@@ -478,11 +481,11 @@ fn render_with_first_navigation_input_selects_first_item(
 
 #[rstest]
 #[ignore]
-#[case(0, "1.10")] // first given no selection -> last item selected
+#[case(0, "1.12.1")] // first given no selection -> last item selected
 #[ignore]
-#[case(10, "1.10")] // down to 1.5 + last -> last item selected
+#[case(10, "1.12.1")] // down to 1.5 + last -> last item selected
 #[ignore]
-#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 1, "1.10")] // down to last item + last -> last item selected
+#[case(TEST_DIRECTORY_TREE_ITEM_COUNT - 1, "1.12.1")] // down to last item + last -> last item selected
 fn render_with_last_navigation_input_selects_last_item(
     #[case] down_count: usize,
     #[case] expected_selected_item_name: &str,
@@ -748,7 +751,7 @@ fn render_given_expand_children_input_for_collapsed_directory_item_expands_all_c
     )?;
 
     // Assert
-    assert_eq!(12, view_state.displayable_item_count);
+    assert_eq!(14, view_state.displayable_item_count);
 
     delete_test_directory_tree(&temp_dir_path);
 

--- a/src/cli/tui_test.rs
+++ b/src/cli/tui_test.rs
@@ -50,7 +50,12 @@ fn render_outputs_crate_version_number() -> anyhow::Result<()> {
     ))]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     output.matches(Regex::new(format!("Space\\s+.*v{}", VERSION).as_str())?)?;
@@ -72,7 +77,12 @@ fn render_outputs_full_path_as_first_row_with_100_percent_size() -> anyhow::Resu
     ))]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     let regex_safe_path = view_state.visible_row_items[0]
@@ -126,7 +136,12 @@ fn render_with_delete_input_without_license_terms_accepted_shows_license_dialog(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     output.expect("Before you are able to delete")?;
@@ -187,7 +202,12 @@ fn render_with_cancelled_delete_does_not_delete_item(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_selected_item_name_eq(expected_selected_item_name, &view_state);
@@ -252,7 +272,12 @@ fn render_with_confirmed_delete_deletes_selected_item(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     // The collected item and all children should be gone.
@@ -315,7 +340,12 @@ fn render_with_navigation_input_selects_correct_item(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_selected_item_name_eq(expected_selected_item_name, &view_state);
@@ -382,7 +412,12 @@ fn render_with_page_up_or_down_navigation_input_selects_correct_item(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_selected_item_name_eq(expected_selected_item_name, &view_state);
@@ -426,7 +461,12 @@ fn render_with_first_navigation_input_selects_first_item(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_selected_item_name_eq(expected_selected_item_name, &view_state);
@@ -470,7 +510,12 @@ fn render_with_last_navigation_input_selects_last_item(
     let mut input_event_source = TestInputEventSource::new(input_events);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_selected_item_name_eq(expected_selected_item_name, &view_state);
@@ -493,7 +538,12 @@ fn render_with_help_key_input_outputs_help() -> anyhow::Result<()> {
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     output.matches(Regex::new(
@@ -544,7 +594,12 @@ fn render_with_view_size_threshold_input_shows_percentage_on_top_line(
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     output.matches(Regex::new(
@@ -576,7 +631,12 @@ fn render_given_collapse_input_for_expanded_directory_item_collapses_it() -> any
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     let item = view_state.visible_row_items[1].borrow();
@@ -605,7 +665,12 @@ fn render_given_expand_input_for_collapsed_directory_item_expands_it() -> anyhow
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     let item = view_state.visible_row_items[1].borrow();
@@ -636,7 +701,12 @@ fn render_given_collapse_children_input_for_directory_item_collapses_all_childre
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     let item = view_state.visible_row_items[1].borrow();
@@ -670,7 +740,12 @@ fn render_given_expand_children_input_for_collapsed_directory_item_expands_all_c
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_eq!(12, view_state.displayable_item_count);
@@ -702,7 +777,12 @@ fn render_given_expand_children_input_for_expanded_directory_item_expands_all_ch
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert_eq!(
@@ -738,7 +818,12 @@ fn render_with_accept_license_input_updates_view_state_and_writes_config_file() 
     ]);
 
     // Act
-    render(&mut view_state, &mut output, &mut input_event_source)?;
+    render(
+        &mut view_state,
+        &mut output,
+        &mut input_event_source,
+        &Skin::default(),
+    )?;
 
     // Assert
     assert!(view_state.accepted_license_terms);

--- a/src/cli/view_command.rs
+++ b/src/cli/view_command.rs
@@ -198,7 +198,9 @@ fn select_skin() -> Skin {
         version_fg_color: Color::Gray,
         table_header_bg_color: Color::DarkGray,
         table_header_fg_color: Color::White,
-        value_fg_color: Color::LightBlue,
+        value_fg_color: None,
+        value_style_invert: true,
+        delete_warning_text_fg_color: Color::LightRed,
         key_help_danger_bg_color: Color::LightRed,
         key_help_key_fg_color: Color::Gray,
         ..Default::default()

--- a/src/cli/view_command.rs
+++ b/src/cli/view_command.rs
@@ -2,6 +2,7 @@
 use super::crossterm_input_event_source::CrosstermInputEventSource;
 use super::{
     cli_command::CliCommand,
+    environment::EnvServiceTrait,
     row_item::RowItem,
     skin::Skin,
     tui,
@@ -11,19 +12,24 @@ use anyhow::{bail, Context};
 use crossterm::{style::Print, QueueableCommand};
 use ratatui::prelude::*;
 use space_rs::{DirectoryItem, SizeDisplayFormat};
-use std::{cell::RefCell, env, io::Write, path::PathBuf, rc::Rc};
+use std::{cell::RefCell, io::Write, path::PathBuf, rc::Rc};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[cfg(test)]
 #[path = "./view_command_test.rs"]
 mod view_command_test;
 
-pub struct ViewCommand {
-    pub target_paths: Option<Vec<PathBuf>>,
-    pub size_display_format: Option<SizeDisplayFormat>,
-    pub size_threshold_percentage: u8,
-    pub non_interactive: bool,
+const COLORTERM_ENV_VAR: &str = "COLORTERM";
+const TERM_ENV_VAR: &str = "TERM";
+
+pub(crate) struct ViewCommand {
+    target_paths: Option<Vec<PathBuf>>,
+    size_display_format: Option<SizeDisplayFormat>,
+    size_threshold_percentage: u8,
+    #[cfg(not(test))]
+    non_interactive: bool,
     total_size_in_bytes: u64,
+    env_service: Box<dyn EnvServiceTrait>,
 }
 
 impl CliCommand for ViewCommand {
@@ -46,7 +52,7 @@ impl CliCommand for ViewCommand {
             // Update args with cleaned target paths.
             self.target_paths = Some(target_paths);
         } else {
-            self.target_paths = Some(vec![env::current_dir()?]);
+            self.target_paths = Some(vec![self.env_service.current_dir()?]);
         }
 
         Ok(self)
@@ -79,7 +85,7 @@ impl CliCommand for ViewCommand {
         let size_threshold_fraction = self.size_threshold_percentage as f32 / 100f32;
         let items = self.get_row_items(items, size_threshold_fraction);
 
-        let skin = select_skin();
+        let skin = self.select_skin();
 
         let mut view_state =
             ViewState::new(items, size_display_format, size_threshold_fraction, &skin);
@@ -107,6 +113,30 @@ impl CliCommand for ViewCommand {
 }
 
 impl ViewCommand {
+    pub fn new(
+        target_paths: Option<Vec<PathBuf>>,
+        size_display_format: Option<SizeDisplayFormat>,
+        size_threshold_percentage: u8,
+        #[cfg(not(test))] non_interactive: bool,
+        env_service: Box<dyn EnvServiceTrait>,
+    ) -> Self {
+        ViewCommand {
+            target_paths,
+            size_display_format,
+            size_threshold_percentage,
+            #[cfg(not(test))]
+            non_interactive,
+            total_size_in_bytes: 0,
+            env_service,
+        }
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn target_paths(&self) -> &Option<Vec<PathBuf>> {
+        &self.target_paths
+    }
+
     #[inline(always)]
     pub fn get_directory_items(&mut self) -> Vec<DirectoryItem> {
         self.analyze_space()
@@ -120,21 +150,6 @@ impl ViewCommand {
             !self.non_interactive
         } else {
             !self.non_interactive && io::stdout().is_tty()
-        }
-    }
-
-    pub fn new(
-        target_paths: Option<Vec<PathBuf>>,
-        size_display_format: Option<SizeDisplayFormat>,
-        size_threshold_percentage: u8,
-        non_interactive: bool,
-    ) -> Self {
-        ViewCommand {
-            target_paths,
-            size_display_format,
-            size_threshold_percentage,
-            non_interactive,
-            total_size_in_bytes: 0,
         }
     }
 
@@ -178,7 +193,7 @@ impl ViewCommand {
                 }
             }
             sanitized_paths.sort();
-        } else if let Ok(current_dir) = env::current_dir() {
+        } else if let Ok(current_dir) = self.env_service.current_dir() {
             sanitized_paths.push(current_dir);
         }
 
@@ -189,53 +204,65 @@ impl ViewCommand {
 
         items
     }
-}
 
-fn select_skin() -> Skin {
-    let low_color = Skin {
-        title_fg_color: Color::White,
-        title_bg_color: Color::Blue,
-        version_fg_color: Color::Gray,
-        table_header_bg_color: Color::DarkGray,
-        table_header_fg_color: Color::White,
-        value_fg_color: None,
-        value_style_invert: true,
-        delete_warning_text_fg_color: Color::LightRed,
-        key_help_danger_bg_color: Color::LightRed,
-        key_help_key_fg_color: Color::Gray,
-        ..Default::default()
-    };
+    fn select_skin(&self) -> Skin {
+        let low_color = Skin {
+            title_fg_color: Color::White,
+            title_bg_color: Color::Blue,
+            version_fg_color: Color::Gray,
+            table_header_bg_color: Color::DarkGray,
+            table_header_fg_color: Color::White,
+            value_fg_color: None,
+            value_style_reversed: true,
+            delete_warning_text_fg_color: Color::LightRed,
+            key_help_danger_bg_color: Color::LightRed,
+            key_help_key_fg_color: Color::Gray,
+            ..Default::default()
+        };
 
-    if let Some(color_count) = get_color_count() {
-        match color_count {
-            ..=256 => low_color,
-            _ => Skin::default(),
+        if let Some(color_count) = self.get_color_count() {
+            match color_count {
+                ..=256 => low_color,
+                _ => Skin::default(),
+            }
+        } else {
+            low_color
         }
-    } else {
-        low_color
     }
-}
 
-fn get_color_count() -> Option<u32> {
-    if let Ok(colorterm) = env::var("COLORTERM").or(env::var("TERM")) {
-        match colorterm.to_lowercase().as_str() {
-            "truecolor" | "24bit" | "24-bit" => Some(16_777_216), // 24-bit color
-            "xterm-256color" | "xterm256" => Some(256),           // 256 colors
-            "xterm" => Some(16),                                  // 16 colors
-            "ansi" => Some(16),                                   // 16 colors
-            "dumb" => None,                                       // No color support
-            "screen" => Some(16),                                 // 16 colors
-            "screen-256color" => Some(256),                       // 256 colors
-            "tmux" => Some(16),                                   // 16 colors
-            "tmux-256color" => Some(256),                         // 256 colors
-            "konsole" => Some(256),                               // 256 colors
-            "rxvt-unicode" => Some(8),                            // 8 colors (customizable)
-            "rxvt-unicode-256color" => Some(256),                 // 256 colors
-            "kitty" | "kitty-256color" => Some(256),              // 256 colors
-            _ => None,                                            // Unknown or custom value
+    fn get_color_count(&self) -> Option<u32> {
+        if let Some(colorterm) = self
+            .env_service
+            .var(COLORTERM_ENV_VAR)
+            .ok()
+            .filter(|colorterm| !colorterm.is_empty())
+            .or_else(|| {
+                self.env_service
+                    .var(TERM_ENV_VAR)
+                    .ok()
+                    .filter(|term| !term.is_empty())
+            })
+        {
+            match colorterm.to_lowercase().as_str() {
+                "truecolor" | "24bit" | "24-bit" => Some(16_777_216), // 24-bit color
+                "kitty" | "kitty-256color" => Some(256),              // 256 colors
+                "konsole" => Some(256),                               // 256 colors
+                "rxvt-unicode-256color" => Some(256),                 // 256 colors
+                "screen-256color" => Some(256),                       // 256 colors
+                "tmux-256color" => Some(256),                         // 256 colors
+                "xterm-256color" | "xterm256" => Some(256),           // 256 colors
+                "ansi" => Some(16),                                   // 16 colors
+                "screen" => Some(16),                                 // 16 colors
+                "tmux" => Some(16),                                   // 16 colors
+                "xterm" => Some(16),                                  // 16 colors
+                "rxvt-unicode" => Some(8),                            // 8 colors (customizable)
+                "dumb" => None,                                       // No color support
+                "monochrome" => None,                                 // No color support
+                _ => None,                                            // Unknown or custom value
+            }
+        } else {
+            None
         }
-    } else {
-        None
     }
 }
 

--- a/src/cli/view_command.rs
+++ b/src/cli/view_command.rs
@@ -192,28 +192,30 @@ impl ViewCommand {
 }
 
 fn select_skin() -> Skin {
-    let default = Skin::default();
+    let low_color = Skin {
+        title_fg_color: Color::White,
+        title_bg_color: Color::Blue,
+        version_fg_color: Color::Gray,
+        table_header_bg_color: Color::DarkGray,
+        table_header_fg_color: Color::White,
+        value_fg_color: Color::LightBlue,
+        key_help_danger_bg_color: Color::LightRed,
+        key_help_key_fg_color: Color::Gray,
+        ..Default::default()
+    };
+
     if let Some(color_count) = get_color_count() {
         match color_count {
-            ..=16 => Skin {
-                table_header_bg_color: Color::Blue,
-                table_header_fg_color: Color::White,
-                title_fg_color: Color::White,
-                title_bg_color: Color::DarkGray,
-                value_fg_color: Color::LightBlue,
-                key_help_danger_bg_color: Color::LightRed,
-                key_help_key_fg_color: Color::Red,
-                ..Default::default()
-            },
-            _ => default,
+            ..=256 => low_color,
+            _ => Skin::default(),
         }
     } else {
-        default
+        low_color
     }
 }
 
 fn get_color_count() -> Option<u32> {
-    if let Ok(colorterm) = env::var("COLORTERM") {
+    if let Ok(colorterm) = env::var("COLORTERM").or(env::var("TERM")) {
         match colorterm.to_lowercase().as_str() {
             "truecolor" | "24bit" | "24-bit" => Some(16_777_216), // 24-bit color
             "xterm-256color" | "xterm256" => Some(256),           // 256 colors

--- a/src/cli/view_command.rs
+++ b/src/cli/view_command.rs
@@ -192,28 +192,47 @@ impl ViewCommand {
 }
 
 fn select_skin() -> Skin {
-    let skin = if let Ok(luma) = terminal_light::luma() {
-        if luma > 0.6 {
-            println!("Selected light skin based on terminal colors");
-            Skin {
-                table_header_bg_color: Color::Rgb(206, 206, 232),
+    let default = Skin::default();
+    if let Some(color_count) = get_color_count() {
+        match color_count {
+            ..=16 => Skin {
+                table_header_bg_color: Color::Blue,
                 table_header_fg_color: Color::White,
                 title_fg_color: Color::White,
-                title_bg_color: Color::Rgb(64, 64, 64),
-                value_fg_color: Color::Rgb(88, 144, 255),
-                key_help_danger_bg_color: Color::Rgb(192, 64, 64),
-                key_help_key_fg_color: Color::Rgb(88, 144, 255),
+                title_bg_color: Color::DarkGray,
+                value_fg_color: Color::LightBlue,
+                key_help_danger_bg_color: Color::LightRed,
+                key_help_key_fg_color: Color::Red,
                 ..Default::default()
-            }
-        } else {
-            println!("Selected dark skin based on terminal colors");
-            Skin::default()
+            },
+            _ => default,
         }
     } else {
-        println!("Selected default dark skin");
-        Skin::default()
-    };
-    skin
+        default
+    }
+}
+
+fn get_color_count() -> Option<u32> {
+    if let Ok(colorterm) = env::var("COLORTERM") {
+        match colorterm.to_lowercase().as_str() {
+            "truecolor" | "24bit" | "24-bit" => Some(16_777_216), // 24-bit color
+            "xterm-256color" | "xterm256" => Some(256),           // 256 colors
+            "xterm" => Some(16),                                  // 16 colors
+            "ansi" => Some(16),                                   // 16 colors
+            "dumb" => None,                                       // No color support
+            "screen" => Some(16),                                 // 16 colors
+            "screen-256color" => Some(256),                       // 256 colors
+            "tmux" => Some(16),                                   // 16 colors
+            "tmux-256color" => Some(256),                         // 256 colors
+            "konsole" => Some(256),                               // 256 colors
+            "rxvt-unicode" => Some(8),                            // 8 colors (customizable)
+            "rxvt-unicode-256color" => Some(256),                 // 256 colors
+            "kitty" | "kitty-256color" => Some(256),              // 256 colors
+            _ => None,                                            // Unknown or custom value
+        }
+    } else {
+        None
+    }
 }
 
 fn render_rows<W: Write>(

--- a/src/cli/view_command_test.rs
+++ b/src/cli/view_command_test.rs
@@ -2,6 +2,7 @@ use crate::{
     cli::{
         cli_command::CliCommand,
         row_item::{RowItem, RowItemType},
+        skin::Skin,
         view_command::ViewCommand,
         view_state_test_utils::make_test_view_state,
     },
@@ -136,6 +137,7 @@ fn render_row_with_size_smaller_than_threshold_does_not_output_anything() -> any
         80,
         SizeDisplayFormat::Metric,
         &mut backend,
+        &Skin::default(),
     )?;
 
     // Assert
@@ -166,7 +168,12 @@ fn render_rows_given_size_threshold_should_render_correct_rows(
     let (view_state, temp_dir_path) = make_test_view_state(0f32)?;
 
     // Act
-    let rendered_count = render_rows(view_state, size_threshold_fraction, &mut output)?;
+    let rendered_count = render_rows(
+        view_state,
+        size_threshold_fraction,
+        &mut output,
+        &Skin::default(),
+    )?;
 
     // Assert
     if expected_rendered_count != rendered_count {

--- a/src/cli/view_command_test.rs
+++ b/src/cli/view_command_test.rs
@@ -1,34 +1,36 @@
+use super::{render_row, render_rows};
 use crate::{
     cli::{
         cli_command::CliCommand,
+        environment::MockEnvServiceTrait,
         row_item::{RowItem, RowItemType},
         skin::Skin,
         view_command::ViewCommand,
-        view_state_test_utils::make_test_view_state,
+        view_state_test_utils::{make_test_view_state, TEST_DIRECTORY_TREE_TOTAL_SIZE},
     },
     test_directory_utils::{create_test_directory_tree, delete_test_directory_tree},
-    test_utils::TestOut,
+    test_utils::{env_service_mock_without_env_vars, TestOut},
 };
+use mockall::predicate::eq;
 use ratatui::prelude::{Constraint, CrosstermBackend};
 use rstest::rstest;
 use space_rs::{
     size::{Size, SizeDisplayFormat},
     DirectoryItem, DirectoryItemType,
 };
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, env::VarError, rc::Rc};
 use uuid::Uuid;
-
-use super::{render_row, render_rows};
 
 #[test]
 fn single_target_path_that_does_not_exist_should_fail() -> anyhow::Result<()> {
     // Arrange
+    let env_service_mock = MockEnvServiceTrait::new();
     let mut view_command = ViewCommand {
         target_paths: Some(vec![std::env::temp_dir().join(Uuid::new_v4().to_string())]),
         size_display_format: None,
         size_threshold_percentage: 1,
-        non_interactive: true,
         total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
     };
 
     // Act
@@ -44,12 +46,13 @@ fn single_target_path_that_does_not_exist_should_fail() -> anyhow::Result<()> {
 #[test]
 fn add_row_item_given_item_of_size_below_threshold_does_not_add_item() {
     // Arrange
+    let env_service_mock = MockEnvServiceTrait::new();
     let view_command = ViewCommand {
         target_paths: None,
         size_display_format: None,
         size_threshold_percentage: 1,
-        non_interactive: false,
         total_size_in_bytes: 1000000,
+        env_service: Box::new(env_service_mock),
     };
     let item = DirectoryItem {
         path_segment: "/some/path".to_string(),
@@ -71,15 +74,18 @@ fn add_row_item_given_item_of_size_below_threshold_does_not_add_item() {
 fn analyze_space_given_no_target_paths_traces_current_dir() -> anyhow::Result<()> {
     // Arrange
     let temp_dir = create_test_directory_tree()?;
-    let current_dir = std::env::current_dir()?;
-    std::env::set_current_dir(&temp_dir)?;
+    let mut env_service_mock = MockEnvServiceTrait::new();
+    let temp_dir_copy = temp_dir.clone();
+    env_service_mock
+        .expect_current_dir()
+        .returning(move || Ok(temp_dir_copy.clone()));
 
     let mut view_command = ViewCommand {
         target_paths: None,
         size_display_format: None,
         size_threshold_percentage: 1,
-        non_interactive: true,
         total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
     };
 
     // Act
@@ -91,12 +97,12 @@ fn analyze_space_given_no_target_paths_traces_current_dir() -> anyhow::Result<()
         temp_dir.display().to_string().as_str(),
         items[0].path_segment
     );
-    assert_eq!(170000, items[0].size_in_bytes.get_value());
+    assert_eq!(
+        TEST_DIRECTORY_TREE_TOTAL_SIZE,
+        items[0].size_in_bytes.get_value()
+    );
     assert_eq!(1, items[0].children.len());
     assert_eq!("1", items[0].children[0].path_segment);
-
-    // Restore the current dir.
-    std::env::set_current_dir(current_dir)?;
 
     delete_test_directory_tree(&temp_dir);
 
@@ -147,18 +153,19 @@ fn render_row_with_size_smaller_than_threshold_does_not_output_anything() -> any
 }
 
 #[rstest]
-#[case(0f32, 25)]
-#[case(0.01f32, 18)]
-#[case(0.02f32, 15)]
-#[case(0.03f32, 13)]
-#[case(0.04f32, 12)]
-#[case(0.08f32, 11)]
-#[case(0.09f32, 9)]
+#[case(0f32, 29)]
+#[case(0.01f32, 20)]
+#[case(0.02f32, 17)]
+#[case(0.03f32, 15)]
+#[case(0.04f32, 14)]
+#[case(0.08f32, 10)]
+#[case(0.09f32, 8)]
 #[case(0.1f32, 8)]
 #[case(0.11f32, 7)]
-#[case(0.14f32, 4)]
+#[case(0.14f32, 2)]
 #[case(0.15f32, 2)]
 #[case(0.2f32, 2)]
+#[case(1f32, 2)]
 fn render_rows_given_size_threshold_should_render_correct_rows(
     #[case] size_threshold_fraction: f32,
     #[case] expected_rendered_count: usize,
@@ -195,19 +202,20 @@ fn run_given_no_size_display_format_defaults_to_metric() -> anyhow::Result<()> {
     // Arrange
     let mut output = TestOut::new();
     let temp_dir = create_test_directory_tree()?;
+    let env_service_mock = env_service_mock_without_env_vars();
     let mut view_command = ViewCommand {
         target_paths: Some(vec![temp_dir.clone()]),
         size_display_format: None,
         size_threshold_percentage: 1,
-        non_interactive: true,
         total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
     };
 
     // Act
     view_command.run(&mut output)?;
 
     // Assert
-    output.expect("170 KB")?;
+    output.expect("180 KB")?;
 
     delete_test_directory_tree(&temp_dir);
 
@@ -219,9 +227,9 @@ fn run_given_no_size_display_format_defaults_to_metric() -> anyhow::Result<()> {
 // using an appropriate terminal multiplexer.
 #[rstest]
 #[ignore]
-#[case(SizeDisplayFormat::Metric, "170 KB")]
+#[case(SizeDisplayFormat::Metric, "180 KB")]
 #[ignore]
-#[case(SizeDisplayFormat::Binary, "166 KiB")]
+#[case(SizeDisplayFormat::Binary, "175 KiB")]
 fn run_with_size_display_format_uses_that_format(
     #[case] size_display_format: SizeDisplayFormat,
     #[case] expected_output: &str,
@@ -229,12 +237,13 @@ fn run_with_size_display_format_uses_that_format(
     // Arrange
     let mut output = TestOut::new();
     let temp_dir = create_test_directory_tree()?;
+    let env_service_mock = env_service_mock_without_env_vars();
     let mut view_command = ViewCommand {
         target_paths: Some(vec![temp_dir.clone()]),
         size_display_format: Some(size_display_format),
         size_threshold_percentage: 1,
-        non_interactive: true,
         total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
     };
 
     // Act
@@ -257,12 +266,13 @@ fn run_given_single_target_path_shows_expected_duration_prompt() -> anyhow::Resu
     // Arrange
     let mut output = TestOut::new();
     let temp_dir = create_test_directory_tree()?;
+    let env_service_mock = env_service_mock_without_env_vars();
     let mut view_command = ViewCommand {
         target_paths: Some(vec![temp_dir.clone()]),
         size_display_format: None,
         size_threshold_percentage: 100,
-        non_interactive: true,
         total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
     };
 
     // Act
@@ -286,12 +296,13 @@ fn run_given_multiple_target_paths_shows_expected_duration_prompt() -> anyhow::R
     let mut output = TestOut::new();
     let temp_dir1 = create_test_directory_tree()?;
     let temp_dir2 = create_test_directory_tree()?;
+    let env_service_mock = env_service_mock_without_env_vars();
     let mut view_command = ViewCommand {
         target_paths: Some(vec![temp_dir1.clone(), temp_dir2.clone()]),
         size_display_format: None,
         size_threshold_percentage: 100,
-        non_interactive: true,
         total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
     };
 
     // Act
@@ -306,4 +317,89 @@ fn run_given_multiple_target_paths_shows_expected_duration_prompt() -> anyhow::R
     delete_test_directory_tree(&temp_dir2);
 
     Ok(())
+}
+
+#[rstest]
+#[case("truecolor", "", Some(16_777_216))]
+#[case("24bit", "", Some(16_777_216))]
+#[case("24-bit", "", Some(16_777_216))]
+#[case("kitty", "", Some(256))]
+#[case("kitty-256color", "", Some(256))]
+#[case("konsole", "", Some(256))]
+#[case("rxvt-unicode-256color", "", Some(256))]
+#[case("screen-256color", "", Some(256))]
+#[case("tmux-256color", "", Some(256))]
+#[case("xterm-256color", "", Some(256))]
+#[case("xterm256", "", Some(256))]
+#[case("ansi", "", Some(16))]
+#[case("screen", "", Some(16))]
+#[case("tmux", "", Some(16))]
+#[case("xterm", "", Some(16))]
+#[case("rxvt-unicode", "", Some(8))]
+#[case("dumb", "", None)]
+#[case("monochrome", "", None)]
+#[case("", "truecolor", Some(16_777_216))]
+#[case("", "24bit", Some(16_777_216))]
+#[case("", "24-bit", Some(16_777_216))]
+#[case("", "kitty", Some(256))]
+#[case("", "kitty-256color", Some(256))]
+#[case("", "konsole", Some(256))]
+#[case("", "rxvt-unicode-256color", Some(256))]
+#[case("", "screen-256color", Some(256))]
+#[case("", "tmux-256color", Some(256))]
+#[case("", "xterm-256color", Some(256))]
+#[case("", "xterm256", Some(256))]
+#[case("", "ansi", Some(16))]
+#[case("", "screen", Some(16))]
+#[case("", "tmux", Some(16))]
+#[case("", "xterm", Some(16))]
+#[case("", "rxvt-unicode", Some(8))]
+#[case("", "dumb", None)]
+#[case("", "monochrome", None)]
+fn get_color_count_return_expected_color_count(
+    #[case] colorterm_value: &str,
+    #[case] term_value: &str,
+    #[case] expected_color_count: Option<u32>,
+) {
+    // Arrange
+    let mut env_service_mock = MockEnvServiceTrait::new();
+    let colorterm_value = colorterm_value.to_string();
+    let term_value = term_value.to_string();
+    if !colorterm_value.is_empty() {
+        env_service_mock
+            .expect_var()
+            .with(eq(crate::cli::view_command::COLORTERM_ENV_VAR))
+            .returning(move |_| Ok(colorterm_value.clone()));
+    } else {
+        env_service_mock
+            .expect_var()
+            .with(eq(crate::cli::view_command::COLORTERM_ENV_VAR))
+            .returning(move |_| Err(VarError::NotPresent));
+    }
+
+    if !term_value.is_empty() {
+        env_service_mock
+            .expect_var()
+            .with(eq(crate::cli::view_command::TERM_ENV_VAR))
+            .returning(move |_| Ok(term_value.clone()));
+    } else {
+        env_service_mock
+            .expect_var()
+            .with(eq(crate::cli::view_command::TERM_ENV_VAR))
+            .returning(move |_| Err(VarError::NotPresent));
+    }
+
+    let view_command = ViewCommand {
+        target_paths: None,
+        size_display_format: None,
+        size_threshold_percentage: 1,
+        total_size_in_bytes: 0,
+        env_service: Box::new(env_service_mock),
+    };
+
+    // Act
+    let color_count = view_command.get_color_count();
+
+    // Assert
+    assert_eq!(expected_color_count, color_count);
 }

--- a/src/cli/view_state_test.rs
+++ b/src/cli/view_state_test.rs
@@ -51,7 +51,7 @@ fn set_size_threshold_fraction_given_selected_item_no_longer_visible_selects_fir
 ) -> anyhow::Result<()> {
     // Arrange
     let (mut view_state, temp_dir_path) = make_test_view_state(0f32)?;
-    select_item_by_name("1.10", &mut view_state)?;
+    select_item_by_name("1.12.1", &mut view_state)?;
 
     // Act
     view_state.set_size_threshold_fraction(0.01f32);
@@ -123,7 +123,7 @@ fn expand_selected_item_given_no_selected_item_should_succeed() {
 #[rstest]
 #[case("1.1", "1")]
 #[case("1.5.2", "1.5")]
-#[case("1.10", "1")]
+#[case("1.11", "1")]
 fn collapse_selected_item_given_leaf_item_collapses_and_selects_parent_item(
     #[case] selected_item_name: &str,
     #[case] parent_item_name: &str,
@@ -197,7 +197,7 @@ fn get_selected_item_given_no_selected_item_returns_none() {
 
 #[rstest]
 #[case(3, 0, 3)] // First invisible item.
-#[case(3, 23, 2)] // Near end - only last 2 items visible.
+#[case(3, 27, 2)] // Near end - only last 2 items visible.
 fn get_selected_item_given_non_visible_or_non_existant_selected_item_returns_none(
     #[case] visible_height: usize,
     #[case] visible_offset: usize,
@@ -308,9 +308,9 @@ fn ensure_visible_given_visible_offset_of_non_zero_should_move_visible_offset_co
 // First page, last item on page selected -> next item that was off page now visible and selected
 #[case(4, 0, 0f32, 3, 3, "1.3")]
 // First page, with page size larger than number of items, last item selected -> last item remains selected
-#[case(10, 0, 0.09f32, 8, 8, "1.6")]
+#[case(10, 0, 0.09f32, 7, 7, "1.5")]
 // Last page, last item selected -> last item remains selected
-#[case(4, 21, 0f32, 3, 3, "1.10")]
+#[case(4, 25, 0f32, 3, 3, "1.12.1")]
 // No visible items
 #[case(4, 0, 1.1f32, 0, 0, "")]
 fn next_selects_expected_item(
@@ -408,11 +408,11 @@ fn subtract_item_tree_size_subtracts_value_from_self_and_ancestors() -> anyhow::
     );
     // Check that ancestors have been updated
     assert_eq!(
-        160000,
+        170000,
         view_state.visible_row_items[1].borrow().size.get_value()
     );
     assert_eq!(
-        160000,
+        170000,
         view_state.visible_row_items[0].borrow().size.get_value()
     );
     // Spot check that siblings were not affected
@@ -431,11 +431,11 @@ fn subtract_item_tree_size_subtracts_value_from_self_and_ancestors() -> anyhow::
 }
 
 #[rstest]
-#[case("1.3", 21, 147000)] // Delete a directory with 3 sub-items
-#[case("1.4", 24, 148000)] // Delete a single file
-#[case("1.5", 14, 152000)] // Delete an empty directory
-#[case("1.5.3.5", 24, 170000)] // Delete an empty directory
-#[case("1.10", 24, 170000)] // Deletes symbolic link to dir, but not the tree it poins to
+#[case("1.3", 25, 157000)] // Delete a directory with 3 sub-items
+#[case("1.4", 28, 158000)] // Delete a single file
+#[case("1.5", 18, 162000)] // Delete a directory with 10 sub-items
+#[case("1.5.3.5", 28, 180000)] // Delete an empty directory
+#[case("1.11", 28, 180000)] // Deletes symbolic link to dir, but not the tree it points to
 fn delete_selected_item_deletes_only_the_selected_item_or_tree_and_updates_sizes(
     #[case] selected_item_name: &str,
     #[case] expected_final_item_count: usize,
@@ -540,8 +540,8 @@ fn last_selects_last_item(
 
 #[rstest]
 #[case("", 2)] // select first item -> only first item and its only child visible
-#[case("1", 12)] // select 1 -> first item, 1 and 1.1 - 1.10 visible
-#[case("1.5.3.5", 25)] // select 1.5.3.5 -> no change
+#[case("1", 14)] // select 1 -> first item, 1 and 1.1 - 1.10 visible
+#[case("1.5.3.5", TEST_DIRECTORY_TREE_ITEM_COUNT)] // select 1.5.3.5 -> no change
 fn collapse_selected_children_filters_correctly(
     #[case] selected_item_name: &str,
     #[case] expected_displayable_item_count: usize,
@@ -568,7 +568,7 @@ fn collapse_selected_children_filters_correctly(
 
 #[rstest]
 #[case("", 2)] // select first item + collapse its children + expand its children -> all displayable
-#[case("1", 12)] // select 1 + collapse its children + expand its children -> all displayable
+#[case("1", 14)] // select 1 + collapse its children + expand its children -> all displayable
 fn expand_selected_children(
     #[case] selected_item_name: &str,
     #[case] expected_displayable_item_count: usize,

--- a/src/cli/view_state_test_utils.rs
+++ b/src/cli/view_state_test_utils.rs
@@ -1,9 +1,12 @@
-use super::{row_item::RowItem, skin::Skin, view_state::ViewState};
+use super::{
+    environment::MockEnvServiceTrait, row_item::RowItem, skin::Skin, view_state::ViewState,
+};
 use crate::{cli::view_command::ViewCommand, test_directory_utils::create_test_directory_tree};
 use space_rs::SizeDisplayFormat;
 use std::{cell::RefCell, path::PathBuf, rc::Rc};
 
-pub(crate) const TEST_DIRECTORY_TREE_ITEM_COUNT: usize = 25;
+pub(crate) const TEST_DIRECTORY_TREE_ITEM_COUNT: usize = 29;
+pub(crate) const TEST_DIRECTORY_TREE_TOTAL_SIZE: u64 = 180000;
 
 pub(crate) fn make_test_view_state(
     size_threshold_fraction: f32,
@@ -40,11 +43,12 @@ pub(crate) fn make_test_view_state_from_path(
     size_threshold_fraction: f32,
 ) -> Result<ViewState, anyhow::Error> {
     let size_display_format = SizeDisplayFormat::Metric;
+    let env_service_mock = MockEnvServiceTrait::new();
     let mut view_command = ViewCommand::new(
         Some(vec![path.clone()]),
         Some(size_display_format.clone()),
         (size_threshold_fraction * 100f32) as u8,
-        false,
+        Box::new(env_service_mock),
     );
     let items = view_command.get_directory_items();
     let items = view_command.get_row_items(items, 0f32);

--- a/src/cli/view_state_test_utils.rs
+++ b/src/cli/view_state_test_utils.rs
@@ -1,4 +1,4 @@
-use super::{row_item::RowItem, view_state::ViewState};
+use super::{row_item::RowItem, skin::Skin, view_state::ViewState};
 use crate::{cli::view_command::ViewCommand, test_directory_utils::create_test_directory_tree};
 use space_rs::SizeDisplayFormat;
 use std::{cell::RefCell, path::PathBuf, rc::Rc};
@@ -49,7 +49,12 @@ pub(crate) fn make_test_view_state_from_path(
     let items = view_command.get_directory_items();
     let items = view_command.get_row_items(items, 0f32);
 
-    let mut view_state = ViewState::new(items, size_display_format, size_threshold_fraction);
+    let mut view_state = ViewState::new(
+        items,
+        size_display_format,
+        size_threshold_fraction,
+        &Skin::default(),
+    );
     view_state.visible_height = visible_height;
     view_state.visible_offset = visible_offset;
     view_state.table_width = 80;

--- a/src/directory_item_test.rs
+++ b/src/directory_item_test.rs
@@ -145,7 +145,7 @@ fn from_root_given_file_path_should_return_only_file_item() -> anyhow::Result<()
 fn build_given_symbolic_link_dir_should_not_follow_link() -> anyhow::Result<()> {
     // Arrange
     let temp_dir = create_test_directory_tree()?;
-    let file_paths = vec![temp_dir.join("1").join("1.10")];
+    let file_paths = vec![temp_dir.join("1").join("1.11")];
 
     // Act
     let items = DirectoryItem::build(file_paths);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,13 @@
 //!
 //! [backlog]: https://github.com/users/emilevr/projects/1
 
-pub mod directory_item;
-pub mod size;
-
 #[cfg(test)]
 mod test_directory_utils;
 
+pub mod directory_item;
 pub use directory_item::DirectoryItem;
 pub use directory_item::DirectoryItemType;
 pub mod rapid_arena;
+pub mod size;
 pub use size::Size;
 pub use size::SizeDisplayFormat;

--- a/src/space_bench.rs
+++ b/src/space_bench.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use clap::{arg, ColorChoice, Parser};
-use cli::{cli_command::CliCommand, view_command::ViewCommand};
+use cli::{cli_command::CliCommand, environment::DefaultEnvService, view_command::ViewCommand};
 use criterion::Criterion;
 use space_rs::SizeDisplayFormat;
 use std::{
@@ -122,7 +122,9 @@ impl BenchmarkCommand {
                     Some(self.target_paths.clone()),
                     Some(self.size_display_format),
                     self.size_threshold_percentage,
+                    #[cfg(not(test))]
                     true,
+                    Box::<DefaultEnvService>::default(),
                 )
                 .prepare()
                 .unwrap()

--- a/src/test_directory_utils.rs
+++ b/src/test_directory_utils.rs
@@ -32,7 +32,17 @@ pub(crate) fn create_test_directory_tree() -> Result<PathBuf, anyhow::Error> {
     create_test_file(d1.join("1.7"), 15000)?;
     create_test_file(d1.join("1.8"), 14000)?;
     create_test_file(d1.join("1.9"), 13000)?;
-    create_test_symlink_dir(d1_5_3, &d1.join("1.10"))?;
+
+    let d1_10 = &d1.join("1.10"); // directory with one file
+    fs::create_dir_all(d1_10)?;
+    create_test_file(d1_10.join("1.10.1"), 10000)?;
+
+    create_test_symlink_dir(d1_5_3, &d1.join("1.11"))?;
+
+    let d1_12 = &d1.join("1.12"); // directory with one symbolic link
+    fs::create_dir_all(d1_12)?;
+    create_test_symlink_dir(d1_10, &d1_12.join("1.12.1"))?;
+
     Ok(temp_dir)
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,9 +1,12 @@
 use anyhow::bail;
 use regex::Regex;
 use std::{
+    env::VarError,
     fmt::Display,
     io::{self, Write},
 };
+
+use crate::cli::environment::MockEnvServiceTrait;
 
 // Custom type for capturing output
 pub(crate) struct TestOut {
@@ -50,7 +53,7 @@ impl TestOut {
 
 fn strip_ansi_escape_sequences(haystack: &str) -> String {
     let strip_ansi_regex = Regex::new("\x1B(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])").unwrap();
-    strip_ansi_regex.replace_all(haystack, "").to_string()
+    strip_ansi_regex.replace_all(haystack, " ").to_string()
 }
 
 impl Write for TestOut {
@@ -73,4 +76,12 @@ impl Display for TestOut {
         )?;
         Ok(())
     }
+}
+
+pub(crate) fn env_service_mock_without_env_vars() -> MockEnvServiceTrait {
+    let mut env_service_mock = MockEnvServiceTrait::new();
+    env_service_mock
+        .expect_var()
+        .returning(|_| Err(VarError::NotPresent));
+    env_service_mock
 }


### PR DESCRIPTION
## Describe your changes
- Added internal support for skins (not yet user configurable).
- Added color capability detection and selection of a suitable skin based on the results.

## PR requirements
- [x] I have followed the guidelines in the [Contribution Guide](../CONTRIBUTING.md#general-guidelines) document.
- [x] I have checked that there aren't other open [Pull Requests](https://github.com/emilevr/space/pulls) for the same update/change.
- [x] I have confirmed locally that there are no linting issues.
- [x] I have confirmed that all tests pass locally.
- [x] I have confirmed that my changes do not negatively impact performance by manually comparing before and
      after performance against a suitable local directory tree.
- [x] I have confirmed that code coverage has not regressed as a result of my changes.